### PR TITLE
Migrate to dry-struct from virtus

### DIFF
--- a/lib/maven/tools/model.rb
+++ b/lib/maven/tools/model.rb
@@ -1,4 +1,6 @@
-require 'virtus'
+require 'dry-types'
+require 'dry-struct'
+require 'dry/struct/with_setters'
 
 # keep things in line with java collections
 class Array
@@ -6,372 +8,285 @@ class Array
     delete( *args )
   end
 end
-    
+
+module Types
+  include Dry.Types()
+end
+
 module Maven
   module Tools
-    Base = Virtus.model
-
-    module GAV
-      def self.included( base )
-        base.attribute :group_id, String
-        base.attribute :artifact_id, String
-        base.attribute :version, String
-      end
-    end
-    module GA
-      def self.included( base )
-        base.attribute :group_id, String
-        base.attribute :artifact_id, String
-      end
-    end
-    module SU
-      def self.included( base )
-        base.attribute :system, String
-        base.attribute :url, String
-      end
-    end
-    module NU
-      def self.included( base )
-        base.attribute :name, String
-        base.attribute :url, String
-      end
-    end
-    module INU
-      def self.included( base )
-        base.attribute :id, String
-        base.attribute :name, String
-        base.attribute :url, String
-      end
+    class Base < Dry::Struct::WithSetters
+      transform_keys(&:to_sym)
     end
 
-    class Parent
-      include Base
-
-      include GAV
-
-      attribute :relative_path, String
+    class GAV < Base
+      attribute? :group_id, Types::Coercible::String.optional
+      attribute? :artifact_id, Types::Coercible::String.optional
+      attribute? :version, Types::Coercible::String.optional
     end
-    class Organization
-      include Base
-
-      include NU
+    class GA < Base
+      attribute? :group_id, Types::Coercible::String.optional
+      attribute? :artifact_id, Types::Coercible::String.optional
     end
-    class License
-      include Base
-
-      include NU
-      attribute :distribution, String
-      attribute :comments, String
+    class SU < Base
+      attribute? :system, Types::Coercible::String.optional
+      attribute? :url, Types::Coercible::String.optional
     end
-    class Developer
-      include Base
-
-      include INU
-      attribute :email, String
-      attribute :organization, String
-      attribute :organization_url, String
-      attribute :roles, String
-      attribute :timezone, String
-      attribute :properties, Hash
+    class NU < Base
+      attribute? :name, Types::Coercible::String.optional
+      attribute? :url, Types::Coercible::String.optional
     end
-    class Contributor
-      include Base
-
-      include NU
-      attribute :email, String
-      attribute :organization, String
-      attribute :organization_url, String
-      attribute :roles, String
-      attribute :timezone, String
-      attribute :properties, Hash
+    class INU < Base
+      attribute? :id, Types::Coercible::String.optional
+      attribute? :name, Types::Coercible::String.optional
+      attribute? :url, Types::Coercible::String.optional
     end
-    class MailingList
-      include Base
 
-      attribute :name, String
-      attribute :subscribe, String
-      attribute :unsubscribe, String
-      attribute :post, String
-      attribute :archive, String
-      attribute :other_archives, Array[ String ]
+    class Parent < GAV
+      attribute? :relative_path, Types::Coercible::String.optional
+    end
+    class Organization < NU; end
+    class License < NU
+      attribute? :distribution, Types::Coercible::String.optional
+      attribute? :comments, Types::Coercible::String.optional
+    end
+    class Developer < INU
+      attribute? :email, Types::Coercible::String.optional
+      attribute? :organization, Types::Coercible::String.optional
+      attribute? :organization_url, Types::Coercible::String.optional
+      attribute? :roles, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :timezone, Types::Coercible::String.optional
+      attribute? :properties, Types::Hash.default { Hash.new }
+    end
+    class Contributor < NU
+      attribute? :email, Types::Coercible::String.optional
+      attribute? :organization, Types::Coercible::String.optional
+      attribute? :organization_url, Types::Coercible::String.optional
+      attribute? :roles, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :timezone, Types::Coercible::String.optional
+      attribute? :properties, Types::Hash.default { Hash.new }
+    end
+    class MailingList < Base
+      attribute? :name, Types::Coercible::String.optional
+      attribute? :subscribe, Types::Coercible::String.optional
+      attribute? :unsubscribe, Types::Coercible::String.optional
+      attribute? :post, Types::Coercible::String.optional
+      attribute? :archive, Types::Coercible::String.optional
+      attribute? :other_archives, Types::Array.of(Types::Coercible::String).default { Array.new }
 
       def archives=( archives )
         self.archive = archives.shift
         self.other_archives = archives
       end
     end
-    class Prerequisites
-      include Base
-
-      attribute :maven, String
+    class Prerequisites < Base
+      attribute? :maven, Types::Coercible::String.optional
     end
-    class Scm
-      include Base
-
-      attribute :connection, String
-      attribute :developer_connection, String
-      attribute :tag, String
-      attribute :url, String
+    class Scm < Base
+      attribute? :connection, Types::Coercible::String.optional
+      attribute? :developer_connection, Types::Coercible::String.optional
+      attribute? :tag, Types::Coercible::String.optional
+      attribute? :url, Types::Coercible::String.optional
     end
-    class IssueManagement
-      include Base
-
-      include SU
+    class IssueManagement < SU
     end
-    class Notifier
-      include Base
-      
-      attribute :type, String
-      attribute :send_on_error, Boolean
-      attribute :send_on_failure, Boolean
-      attribute :send_on_success, Boolean
-      attribute :send_on_warning, Boolean
-      attribute :address, String
-      attribute :configuration, Hash
+    class Notifier < Base
+      attribute? :type, Types::Coercible::String.optional
+      attribute? :send_on_error, Types::Params::Bool
+      attribute? :send_on_failure, Types::Params::Bool
+      attribute? :send_on_success, Types::Params::Bool
+      attribute? :send_on_warning, Types::Params::Bool
+      attribute? :address, Types::Coercible::String.optional
+      attribute? :configuration, Types::Hash.default { Hash.new }
     end
-    class CiManagement
-      include Base
-
-      include SU
-      
-      attribute :notifiers, Array[ Notifier ]
+    class CiManagement < SU
+      attribute? :notifiers, Types::Array.of( Notifier ).default { Array.new }
     end
-    class Site
-      include Base
-
-      include INU
+    class Site < INU
     end
-    class Relocation
-      include Base
-
-      include GAV
-      attribute :message, String
+    class Relocation < GAV
+      attribute? :message, Types::Coercible::String.optional
     end
-    class RepositoryPolicy
-      include Base
-
-      attribute :enabled, Boolean
-      attribute :update_policy, String
-      attribute :checksum_policy, String
+    class RepositoryPolicy < Base
+      attribute? :enabled, Types::Params::Bool
+      attribute? :update_policy, Types::Coercible::String.optional
+      attribute? :checksum_policy, Types::Coercible::String.optional
     end
-    class Repository
-      include Base
-
-      attribute :releases, RepositoryPolicy
-      attribute :snapshots, RepositoryPolicy
-
-      include INU
-
-      attribute :layout, String
+    class Repository < INU
+      attribute? :releases, RepositoryPolicy.optional
+      attribute? :snapshots, RepositoryPolicy.optional
+      attribute? :layout, Types::Coercible::String.optional
     end
     class PluginRepository < Repository; end
     class DeploymentRepository < Repository; end
-    class DistributionManagement
-      include Base
-
-      attribute :repository, Repository
-      attribute :snapshot_repository, Repository
-      attribute :site, Site
-      attribute :download_url, String
-      attribute :status, String
-      attribute :relocation, Relocation
+    class DistributionManagement < Base
+      attribute? :repository, Repository.optional
+      attribute? :snapshot_repository, Repository.optional
+      attribute? :site, Site.optional
+      attribute? :download_url, Types::Coercible::String.optional
+      attribute? :status, Types::Coercible::String.optional
+      attribute? :relocation, Relocation.optional
     end
-    class Exclusion
-      include Base
-
-      include GA
-    end
-    class Dependency
-      include Base
-
-      include GAV
-
-      attribute :type, String
-      attribute :classifier, String
-      attribute :scope, String
-      attribute :system_path, String
-      attribute :exclusions, Array[ Exclusion ]
-      attribute :optional, Boolean
+    class Exclusion < GA; end
+    class Dependency < Base
+      attribute? :group_id, Types::Coercible::String.optional
+      attribute? :artifact_id, Types::Coercible::String.optional
+      attribute? :version, Types::Coercible::String.optional
+      attribute? :type, Types::Coercible::String.optional
+      attribute? :classifier, Types::Coercible::String.optional
+      attribute? :scope, Types::Coercible::String.optional
+      attribute? :system_path, Types::Coercible::String.optional
+      attribute? :exclusions, Types::Array.of( Exclusion ).default { Array.new }
+      attribute? :optional, Types::Params::Bool
 
       # silent default
       def type=( t )
         if t.to_sym == :jar
-          @type = nil
+          @attributes['type']  = nil
         else
-          @type = t
+          @attributes['type']  = t
         end
       end
     end
-    class DependencyManagement
-      include Base
-
-      attribute :dependencies, Array[ Dependency ]
+    class DependencyManagement < Base
+      attribute? :dependencies, Types::Array.of( Dependency ).default { Array.new }
     end
-    class Extension
-      include Base
-
-      include GAV
+    class Extension < GAV; end
+    class Resource < Base
+      attribute? :target_path, Types::Coercible::String.optional
+      attribute? :filtering, Types::Coercible::String.optional
+      attribute? :directory, Types::Coercible::String.optional
+      attribute? :includes, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :excludes, Types::Array.of(Types::Coercible::String).default { Array.new }
     end
-    class Resource
-      include Base
-
-      attribute :target_path, String
-      attribute :filtering, String
-      attribute :directory, String
-      attribute :includes, Array[ String ]
-      attribute :excludes, Array[ String ]
+    class Execution < Base
+      attribute? :id, Types::Coercible::String.optional
+      attribute? :phase, Types::Coercible::String.optional
+      attribute? :goals, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :inherited, Types::Params::Bool
+      attribute? :configuration, Types::Hash.default { Hash.new }
     end
-    class Execution
-      include Base
-
-      attribute :id, String
-      attribute :phase, String
-      attribute :goals, Array[ String ]
-      attribute :inherited, Boolean
-      attribute :configuration, Hash
-    end
-    class Plugin
-      include Base
-
-      include GAV
-      attribute :extensions, Boolean
-      attribute :executions, Array[ Execution ]
-      attribute :dependencies, Array[ Dependency ]
-      attribute :goals, Array[ String ]
-      attribute :inherited, Boolean
-      attribute :configuration, Hash
+    class Plugin < Base
+      attribute? :group_id, Types::Coercible::String.optional
+      attribute? :artifact_id, Types::Coercible::String.optional
+      attribute? :version, Types::Coercible::String.optional
+      attribute? :extensions, Types::Params::Bool
+      attribute? :executions, Types::Array.of( Execution ).default { Array.new }
+      attribute? :dependencies, Types::Array.of( Dependency ).default { Array.new }
+      attribute? :goals, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :inherited, Types::Params::Bool
+      attribute? :configuration, Types::Hash.default { Hash.new }
 
       # silent default
       def group_id=( v )
         if v.to_s == 'org.apache.maven.plugins'
-          @group_id = nil
+          @attributes['group_id'] = nil
         else
-          @group_id = v
+          @attributes['group_id'] = v
         end
       end
     end
-    class PluginManagement
-      include Base
-
-      attribute :plugins, Array[ Plugin ]
+    class PluginManagement < Base
+      attribute? :plugins, Types::Array.of( Plugin ).default { Array.new }
     end
-    class ReportSet
-      include Base
-
-      attribute :id, String
-      attribute :reports, Array[ String ]
-      attribute :inherited, Boolean
-      attribute :configuration, Hash
+    class ReportSet < Base
+      attribute? :id, Types::Coercible::String.optional
+      attribute? :reports, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :inherited, Types::Params::Bool
+      attribute? :configuration, Types::Hash.default { Hash.new }
     end
-    class ReportPlugin
-      include Base
-
-      include GAV
-
-      attribute :report_sets, Array[ ReportSet ]
+    class ReportPlugin < GAV
+      attribute? :report_sets, Types::Array.of( ReportSet ).default { Array.new }
     end
-    class Reporting
-      include Base
-
-      attribute :exclude_defaults, Boolean
-      attribute :output_directory, String
-      attribute :plugins, Array[ ReportPlugin ]
+    class Reporting < Base
+      attribute? :exclude_defaults, Types::Params::Bool
+      attribute? :output_directory, Types::Coercible::String.optional
+      attribute? :plugins, Types::Array.of( ReportPlugin ).default { Array.new }
     end
-    class Build
-      include Base
-
-      attribute :source_directory, String
-      attribute :script_source_directory, String
-      attribute :test_source_directory, String
-      attribute :output_directory, String
-      attribute :test_output_directory, String
-      attribute :extensions, Array[ Extension ]
-      attribute :default_goal, String
-      attribute :resources, Array[ Resource ]
-      attribute :test_resources, Array[ Resource ]
-      attribute :directory, String
-      attribute :final_name, String
-      attribute :filters, Array[ String ]
-      attribute :plugin_management, PluginManagement
-      attribute :plugins, Array[ Plugin ]
+    class Build < Base
+      attribute? :source_directory, Types::Coercible::String.optional
+      attribute? :script_source_directory, Types::Coercible::String.optional
+      attribute? :test_source_directory, Types::Coercible::String.optional
+      attribute? :output_directory, Types::Coercible::String.optional
+      attribute? :test_output_directory, Types::Coercible::String.optional
+      attribute? :extensions, Types::Array.of( Extension ).default { Array.new }
+      attribute? :default_goal, Types::Coercible::String.optional
+      attribute? :resources, Types::Array.of( Resource ).default { Array.new }
+      attribute? :test_resources, Types::Array.of(  Resource  ).default { Array.new }
+      attribute? :directory, Types::Coercible::String.optional
+      attribute? :final_name, Types::Coercible::String.optional
+      attribute? :filters, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :plugin_management, PluginManagement.optional
+      attribute? :plugins, Types::Array.of( Plugin ).default { Array.new }
     end
-    class ActivationOS
-      include Base
-
-      attribute :name, String
-      attribute :family, String
-      attribute :arch, String
-      attribute :version, String
+    class ActivationOS < Base
+      attribute? :name, Types::Coercible::String.optional
+      attribute? :family, Types::Coercible::String.optional
+      attribute? :arch, Types::Coercible::String.optional
+      attribute? :version, Types::Coercible::String.optional
     end
-    class ActivationProperty
-      include Base
-
-      attribute :name, String
-      attribute :value, String
+    class ActivationProperty < Base
+      attribute? :name, Types::Coercible::String.optional
+      attribute? :value, Types::Coercible::String.optional
     end
-    class ActivationFile
-      include Base
-
-      attribute :missing, String
-      attribute :exists, String
+    class ActivationFile < Base
+      attribute? :missing, Types::Coercible::String.optional
+      attribute? :exists, Types::Coercible::String.optional
     end
-    class Activation
-      include Base
-
-      attribute :active_by_default, Boolean
-      attribute :jdk, String
-      attribute :os, ActivationOS
-      attribute :property, ActivationProperty
-      attribute :file, ActivationFile
+    class Activation < Base
+      attribute? :active_by_default, Types::Params::Bool
+      attribute? :jdk, Types::Coercible::String.optional
+      attribute? :os, ActivationOS.optional
+      attribute? :property, ActivationProperty.optional
+      attribute? :file, ActivationFile.optional
     end
-    class Profile
-      include Base
-
-      attribute :id, String
-      attribute :activation, Activation
-      attribute :build, Build
-      attribute :modules, Array[ String ]
-      attribute :distribution_management, DistributionManagement
-      attribute :properties, Hash
-      attribute :dependency_management, DependencyManagement
-      attribute :dependencies, Array[ Dependency ]
-      attribute :repositories, Array[ Repository ]
-      attribute :plugin_repositories, Array[ PluginRepository ]
-      attribute :reporting, Reporting
+    class Profile < Base
+      attribute? :id, Types::Coercible::String.optional
+      attribute? :activation, Activation.optional
+      attribute? :build, Build.optional
+      attribute? :modules, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :distribution_management, DistributionManagement.optional
+      attribute? :properties, Types::Hash.default { Hash.new }
+      attribute? :dependency_management, DependencyManagement.optional
+      attribute? :dependencies, Types::Array.of( Dependency ).default { Array.new }
+      attribute? :repositories, Types::Array.of( Repository ).default { Array.new }
+      attribute? :plugin_repositories, Types::Array.of( PluginRepository ).default { Array.new }
+      attribute? :reporting, Reporting.optional
     end
-    class Model
-      include Base
+    class Model < Base
+      attribute? :model_version, Types::Coercible::String.optional
+      attribute? :parent, Parent.optional
 
-      attribute :model_version, String
-      attribute :parent, Parent
+      attribute? :group_id, Types::Coercible::String.optional
+      attribute? :artifact_id, Types::Coercible::String.optional
+      attribute? :version, Types::Coercible::String.optional
 
-      include GAV
+      attribute? :packaging, Types::Coercible::String.optional
 
-      attribute :packaging, String
+      attribute? :name, Types::Coercible::String.optional
+      attribute? :url, Types::Coercible::String.optional
 
-      include NU
-
-      attribute :description, String
-      attribute :inception_year, String
-      attribute :organization, Organization
-      attribute :licenses, Array[ License ]
-      attribute :developers, Array[ Developer ]
-      attribute :contributors, Array[ Contributor ]
-      attribute :mailing_lists, Array[ MailingList ]
-      attribute :prerequisites, Prerequisites
-      attribute :modules, Array[ String ]
-      attribute :scm, Scm
-      attribute :issue_management, IssueManagement
-      attribute :ci_management, CiManagement
-      attribute :distribution_management, DistributionManagement
-      attribute :properties, Hash
-      attribute :dependency_management, DependencyManagement
-      attribute :dependencies, Array[ Dependency ]
-      attribute :repositories, Array[ Repository ]
-      attribute :plugin_repositories, Array[ PluginRepository ]
-      attribute :build, Build
-      attribute :reporting, Reporting
-      attribute :profiles, Array[ Profile ]
+      attribute? :description, Types::Coercible::String.optional
+      attribute? :inception_year, Types::Coercible::String.optional
+      attribute? :organization, Organization.optional
+      attribute? :licenses, Types::Array.of( License ).default { Array.new }
+      attribute? :developers, Types::Array.of( Developer ).default { Array.new }
+      attribute? :contributors, Types::Array.of( Contributor ).default { Array.new }
+      attribute? :mailing_lists, Types::Array.of( MailingList ).default { Array.new }
+      attribute? :prerequisites, Prerequisites.optional
+      attribute? :modules, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :scm, Scm.optional
+      attribute? :issue_management, IssueManagement.optional
+      attribute? :ci_management, CiManagement.optional
+      attribute? :distribution_management, DistributionManagement.optional
+      attribute? :properties, Types::Hash.default { Hash.new }
+      attribute? :dependency_management, DependencyManagement.optional
+      attribute? :dependencies, Types::Array.of( Dependency ).default { Array.new }
+      attribute? :repositories, Types::Array.of( Repository ).default { Array.new }
+      attribute? :plugin_repositories, Types::Array.of( PluginRepository ).default { Array.new }
+      attribute? :build, Build.optional
+      attribute? :reporting, Reporting.optional
+      attribute? :profiles, Types::Array.of( Profile ).default { Array.new }
     end
   end
 end

--- a/lib/maven/tools/version.rb
+++ b/lib/maven/tools/version.rb
@@ -20,6 +20,6 @@
 #
 module Maven
   module Tools
-    VERSION = '1.1.7'.freeze
+    VERSION = '1.2.0'.freeze
   end
 end

--- a/lib/maven/tools/visitor.rb
+++ b/lib/maven/tools/visitor.rb
@@ -65,7 +65,7 @@ module Maven
           buffer.push( buffer.empty? ? e : e.capitalize )
         end.join
       end
-      
+
       def accept_project( project )
         accept( 'project', project )
         @io.close if @io.respond_to? :close
@@ -144,7 +144,7 @@ module Maven
           end_tag( name )
         end
       end
-      
+
       def escape_value( value )
         value = value.to_s.dup
         value.gsub!( /&/, '&amp;' )

--- a/maven-tools.gemspec
+++ b/maven-tools.gemspec
@@ -28,7 +28,14 @@ Gem::Specification.new do |s|
   s.test_files += Dir['spec/**/*gemspec']
   s.test_files += Dir['spec/**/*gem']
 
-  s.add_runtime_dependency 'virtus', '~> 1.0'
+  s.add_runtime_dependency 'dry-container', '~> 0.7.2'
+  s.add_runtime_dependency 'dry-configurable', '~> 0.12.1'
+  s.add_runtime_dependency 'dry-core', '~> 0.6.0'
+  s.add_runtime_dependency 'dry-inflector', '~> 0.2.0'
+  s.add_runtime_dependency 'dry-types', '~> 1.5.1'
+  s.add_runtime_dependency 'dry-struct', '~> 1.4.0'
+  s.add_runtime_dependency 'dry-struct-setters', '~> 0.4.0'
+
 
 # get them out from here until jruby-maven-plugin installs test gems somewhere else then runtime gems
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,4 @@
 <project>
-  <url>http://github.com/torquebox/maven-tools</url>
-  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
-
   <developers>
     <developer>
       <name>Christian Meier</name>
@@ -24,60 +21,60 @@
   </properties>
   <dependencies>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>dry-container</artifactId>
       <version>0.7.2</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>dry-configurable</artifactId>
       <version>0.12.1</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>dry-core</artifactId>
       <version>0.6.0</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>dry-inflector</artifactId>
       <version>0.2.0</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>dry-types</artifactId>
       <version>1.5.1</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>dry-struct</artifactId>
       <version>1.4.0</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>dry-struct-setters</artifactId>
       <version>0.4.0</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>rake</artifactId>
       <version>10.5.0</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>minitest</artifactId>
       <version>5.15.0</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <modelVersion>4.0.0</modelVersion>
@@ -94,27 +91,29 @@
         <version>1.0.3</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
+        <configuration>
+          <gemspec>maven-tools.gemspec</gemspec>
+        </configuration>
         <groupId>de.saumya.mojo</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>${jruby.plugins.version}</version>
         <extensions>true</extensions>
-        <configuration>
-          <gemspec>maven-tools.gemspec</gemspec>
-        </configuration>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>minitest-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <executions>
           <execution>
             <goals><goal>spec</goal></goals>
           </execution>
         </executions>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>minitest-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
+  <url>http://github.com/torquebox/maven-tools</url>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,7 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>maven-tools</artifactId>
-  <version>1.1.6</version>
-  <packaging>gem</packaging>
-  <name>helpers for maven related tasks</name>
   <url>http://github.com/torquebox/maven-tools</url>
   <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
+
   <developers>
     <developer>
       <name>Christian Meier</name>
@@ -19,17 +14,8 @@
   </scm>
   <repositories>
     <repository>
-      <id>rubygems</id>
-      <name>Rubygems Proxy</name>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <layout>default</layout>
-        <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
-      </snapshots>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
   <properties>
@@ -39,31 +25,73 @@
   <dependencies>
     <dependency>
       <groupId>rubygems</groupId>
-      <artifactId>virtus</artifactId>
-      <version>[1.0,1.99999]</version>
+      <artifactId>dry-container</artifactId>
+      <version>0.7.2</version>
+      <type>gem</type>
+    </dependency>
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-configurable</artifactId>
+      <version>0.12.1</version>
+      <type>gem</type>
+    </dependency>
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-core</artifactId>
+      <version>0.6.0</version>
+      <type>gem</type>
+    </dependency>
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-inflector</artifactId>
+      <version>0.2.0</version>
+      <type>gem</type>
+    </dependency>
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-types</artifactId>
+      <version>1.5.1</version>
+      <type>gem</type>
+    </dependency>
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-struct</artifactId>
+      <version>1.4.0</version>
+      <type>gem</type>
+    </dependency>
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-struct-setters</artifactId>
+      <version>0.4.0</version>
       <type>gem</type>
     </dependency>
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>rake</artifactId>
-      <version>[10.0,10.99999]</version>
+      <version>10.5.0</version>
       <type>gem</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>minitest</artifactId>
-      <version>[5.3,5.99999]</version>
+      <version>5.15.0</version>
       <type>gem</type>
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <modelVersion>4.0.0</modelVersion>
+  <name>helpers for maven related tasks</name>
+  <groupId>rubygems</groupId>
+  <artifactId>maven-tools</artifactId>
+  <version>1.2.0</version>
+  <packaging>gem</packaging>
   <build>
     <extensions>
       <extension>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-extension</artifactId>
-        <version>${jruby.plugins.version}</version>
+        <groupId>org.torquebox.mojo</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>1.0.3</version>
       </extension>
     </extensions>
     <directory>${basedir}/pkg</directory>
@@ -72,6 +100,7 @@
         <groupId>de.saumya.mojo</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>${jruby.plugins.version}</version>
+        <extensions>true</extensions>
         <configuration>
           <gemspec>maven-tools.gemspec</gemspec>
         </configuration>

--- a/spec/artifact_spec.rb
+++ b/spec/artifact_spec.rb
@@ -4,67 +4,67 @@ require 'maven/tools/artifact'
 describe Maven::Tools::Artifact do
 
   it 'should convert from coordinate' do
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:123' ).to_s.must_equal 'sdas:das:jar:tes:123'
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:123' ).to_s.must_equal 'sdas:das:jar:123'
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:[123,234]' ).to_s.must_equal 'sdas:das:jar:tes:[123,234]'
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:[123,234]' ).to_s.must_equal 'sdas:das:jar:[123,234]'
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:123:[de:fr,gb:us]' ).to_s.must_equal 'sdas:das:jar:tes:123:[de:fr,gb:us]'
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:123:[de:fr,gb:us]' ).to_s.must_equal 'sdas:das:jar:123:[de:fr,gb:us]'
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:[123,234]:[de:fr,gb:us]' ).to_s.must_equal 'sdas:das:jar:tes:[123,234]:[de:fr,gb:us]'
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:[123,234]:[de:fr,gb:us]' ).to_s.must_equal 'sdas:das:jar:[123,234]:[de:fr,gb:us]'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:123' ).to_s).must_equal 'sdas:das:jar:tes:123'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:123' ).to_s).must_equal 'sdas:das:jar:123'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:[123,234]' ).to_s).must_equal 'sdas:das:jar:tes:[123,234]'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:[123,234]' ).to_s).must_equal 'sdas:das:jar:[123,234]'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:123:[de:fr,gb:us]' ).to_s).must_equal 'sdas:das:jar:tes:123:[de:fr,gb:us]'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:123:[de:fr,gb:us]' ).to_s).must_equal 'sdas:das:jar:123:[de:fr,gb:us]'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:[123,234]:[de:fr,gb:us]' ).to_s).must_equal 'sdas:das:jar:tes:[123,234]:[de:fr,gb:us]'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:[123,234]:[de:fr,gb:us]' ).to_s).must_equal 'sdas:das:jar:[123,234]:[de:fr,gb:us]'
   end
 
   it 'should setup artifact' do
-    Maven::Tools::Artifact.new( "sdas", "das", "jar", "123", "tes" ).to_s.must_equal 'sdas:das:jar:tes:123'
-    Maven::Tools::Artifact.new( "sdas", "das", "jar", "123" ).to_s.must_equal 'sdas:das:jar:123'
-    Maven::Tools::Artifact.new( "sdas.asd", "das", "jar", "123", ["fds:fre"] ).to_s.must_equal 'sdas.asd:das:jar:123:[fds:fre]'
-    Maven::Tools::Artifact.new( "sdas.asd", "das", "jar","123",  "bla", ["fds:fre", "ferf:de"] ).to_s.must_equal 'sdas.asd:das:jar:bla:123:[fds:fre,ferf:de]'
-    Maven::Tools::Artifact.new( "sdas.asd", "das", "jar", "123", "blub", ["fds:fre", "ferf:de"] ).to_s.must_equal 'sdas.asd:das:jar:blub:123:[fds:fre,ferf:de]'
+    _(Maven::Tools::Artifact.new( "sdas", "das", "jar", "123", "tes" ).to_s).must_equal 'sdas:das:jar:tes:123'
+    _(Maven::Tools::Artifact.new( "sdas", "das", "jar", "123" ).to_s).must_equal 'sdas:das:jar:123'
+    _(Maven::Tools::Artifact.new( "sdas.asd", "das", "jar", "123", ["fds:fre"] ).to_s).must_equal 'sdas.asd:das:jar:123:[fds:fre]'
+    _(Maven::Tools::Artifact.new( "sdas.asd", "das", "jar","123",  "bla", ["fds:fre", "ferf:de"] ).to_s).must_equal 'sdas.asd:das:jar:bla:123:[fds:fre,ferf:de]'
+    _(Maven::Tools::Artifact.new( "sdas.asd", "das", "jar", "123", "blub", ["fds:fre", "ferf:de"] ).to_s).must_equal 'sdas.asd:das:jar:blub:123:[fds:fre,ferf:de]'
   end
 
   it 'should convert ruby version contraints - gems' do
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '=1' ).to_s.must_equal 'rubygems:asd:gem:[1,1.0.0.0.0.1)'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '>=1' ).to_s.must_equal 'rubygems:asd:gem:[1,)'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<=1' ).to_s.must_equal 'rubygems:asd:gem:[0,1]'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '>1' ).to_s.must_equal 'rubygems:asd:gem:(1,)'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<1' ).to_s.must_equal 'rubygems:asd:gem:[0,1)'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '!=1' ).to_s.must_equal 'rubygems:asd:gem:(1,)'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<2', '>1' ).to_s.must_equal 'rubygems:asd:gem:(1,2)'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<=2', '>1' ).to_s.must_equal 'rubygems:asd:gem:(1,2]'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<2', '>=1' ).to_s.must_equal 'rubygems:asd:gem:[1,2)'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<=2', '>=1' ).to_s.must_equal 'rubygems:asd:gem:[1,2]'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '=1' ).to_s).must_equal 'rubygems:asd:gem:[1,1.0.0.0.0.1)'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '>=1' ).to_s).must_equal 'rubygems:asd:gem:[1,)'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<=1' ).to_s).must_equal 'rubygems:asd:gem:[0,1]'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '>1' ).to_s).must_equal 'rubygems:asd:gem:(1,)'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<1' ).to_s).must_equal 'rubygems:asd:gem:[0,1)'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '!=1' ).to_s).must_equal 'rubygems:asd:gem:(1,)'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<2', '>1' ).to_s).must_equal 'rubygems:asd:gem:(1,2)'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<=2', '>1' ).to_s).must_equal 'rubygems:asd:gem:(1,2]'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<2', '>=1' ).to_s).must_equal 'rubygems:asd:gem:[1,2)'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<=2', '>=1' ).to_s).must_equal 'rubygems:asd:gem:[1,2]'
   end
 
   it 'should convert ruby version contraints - jars' do
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '=1' ).to_s.must_equal 'org.something:asd:jar:[1,1.0.0.0.0.1)'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '>=1' ).to_s.must_equal 'org.something:asd:jar:[1,)'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<=1' ).to_s.must_equal 'org.something:asd:jar:[0,1]'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '>1' ).to_s.must_equal 'org.something:asd:jar:(1,)'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<1' ).to_s.must_equal 'org.something:asd:jar:[0,1)'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '!=1' ).to_s.must_equal 'org.something:asd:jar:(1,)'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<2', '>1' ).to_s.must_equal 'org.something:asd:jar:(1,2)'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<=2', '>1' ).to_s.must_equal 'org.something:asd:jar:(1,2]'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<2', '>=1' ).to_s.must_equal 'org.something:asd:jar:[1,2)'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<=2', '>=1' ).to_s.must_equal 'org.something:asd:jar:[1,2]'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '=1' ).to_s).must_equal 'org.something:asd:jar:[1,1.0.0.0.0.1)'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '>=1' ).to_s).must_equal 'org.something:asd:jar:[1,)'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<=1' ).to_s).must_equal 'org.something:asd:jar:[0,1]'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '>1' ).to_s).must_equal 'org.something:asd:jar:(1,)'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<1' ).to_s).must_equal 'org.something:asd:jar:[0,1)'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '!=1' ).to_s).must_equal 'org.something:asd:jar:(1,)'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<2', '>1' ).to_s).must_equal 'org.something:asd:jar:(1,2)'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<=2', '>1' ).to_s).must_equal 'org.something:asd:jar:(1,2]'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<2', '>=1' ).to_s).must_equal 'org.something:asd:jar:[1,2)'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<=2', '>=1' ).to_s).must_equal 'org.something:asd:jar:[1,2]'
   end  
 
   it 'passes in scope to artifact' do
     a = Maven::Tools::Artifact.from( :jar, 'org.something:asd', '1' )
-    a.to_s.must_equal 'org.something:asd:jar:1'
+    _(a.to_s).must_equal 'org.something:asd:jar:1'
     a[ :scope ].must_be_nil
     a = Maven::Tools::Artifact.from( :jar, 'org.something:asd', '1', :scope => :provided )
-    a.to_s.must_equal 'org.something:asd:jar:1'
-    a[ :scope ].must_equal :provided
+    _(a.to_s).must_equal 'org.something:asd:jar:1'
+    _(a[ :scope ]).must_equal :provided
   end
   it 'passes in exclusions to artifact' do
     a = Maven::Tools::Artifact.from( :jar, 'org.something:asd', '1' )
-    a.to_s.must_equal 'org.something:asd:jar:1'
+    _(a.to_s).must_equal 'org.something:asd:jar:1'
     a[ :exclusions ].must_be_nil
     a = Maven::Tools::Artifact.from( :jar, 'org.something:asd', '1', :exclusions => ["org.something:dsa"] )
-    a.to_s.must_equal 'org.something:asd:jar:1:[org.something:dsa]'
-    a[ :exclusions ].must_equal [ 'org.something:dsa' ]
+    _(a.to_s).must_equal 'org.something:asd:jar:1:[org.something:dsa]'
+    _(a[ :exclusions ]).must_equal [ 'org.something:dsa' ]
     a = Maven::Tools::Artifact.from( :jar, 'org.something:asd', '1', :exclusions => ["org.something:dsa", "org.anything:qwe"] )
-    a.to_s.must_equal 'org.something:asd:jar:1:[org.something:dsa,org.anything:qwe]'
-    a[ :exclusions ].must_equal [ 'org.something:dsa', 'org.anything:qwe' ]
+    _(a.to_s).must_equal 'org.something:asd:jar:1:[org.something:dsa,org.anything:qwe]'
+    _(a[ :exclusions ]).must_equal [ 'org.something:dsa', 'org.anything:qwe' ]
   end
 end

--- a/spec/coordinate_spec.rb
+++ b/spec/coordinate_spec.rb
@@ -9,75 +9,75 @@ describe Maven::Tools::Coordinate do
   subject { A.new }
 
   it 'should convert ruby version to maven version ranges' do
-    subject.to_version.must_equal "[0,)"
-    subject.to_version('!=2.3.4').must_equal "(2.3.4,)"
-    subject.to_version('!=2.3.4.rc').must_equal "(2.3.4.rc-SNAPSHOT,)"
-    subject.to_version('=2.3.4').must_equal "[2.3.4,2.3.4.0.0.0.0.1)"
-    subject.to_version('=2.3.4.alpha').must_equal "2.3.4.alpha"
-    subject.to_version('~>1.8.2').must_equal "[1.8.2,1.8.99999]"
-    subject.to_version('~>1.8.2.beta').must_equal "[1.8.2.beta-SNAPSHOT,1.8.99999]"
-    subject.to_version('~>1.8.2.beta123.12').must_equal "[1.8.2.beta123.12-SNAPSHOT,1.8.99999]"
-    subject.to_version('~>1.8.2.1beta').must_equal "[1.8.2.1beta-SNAPSHOT,1.8.99999]"
-    subject.to_version('~>1.8').must_equal "[1.8,1.99999]"
-    subject.to_version('~>0').must_equal "[0,99999]"
-    subject.to_version('>1.2').must_equal "(1.2,)"
-    subject.to_version('>1.2.GA').must_equal "(1.2.GA-SNAPSHOT,)"
-    subject.to_version('<1.2').must_equal "[0,1.2)"
-    subject.to_version('<1.2.dev').must_equal "[0,1.2.dev-SNAPSHOT)"
-    subject.to_version('>=1.2').must_equal "[1.2,)"
-    subject.to_version('>=1.2.gamma').must_equal "[1.2.gamma-SNAPSHOT,)"
-    subject.to_version('<=1.2').must_equal "[0,1.2]"
-    subject.to_version('<=1.2.pre').must_equal "[0,1.2.pre-SNAPSHOT]"
-    subject.to_version('>=1.2', '<2.0').must_equal "[1.2,2.0)"
-    subject.to_version('>=1.2', '<=2.0').must_equal "[1.2,2.0]"
-    subject.to_version('>1.2', '<2.0').must_equal "(1.2,2.0)"
-    subject.to_version('>1.2', '<=2.0').must_equal "(1.2,2.0]"
+    _(subject.to_version).must_equal "[0,)"
+    _(subject.to_version('!=2.3.4')).must_equal "(2.3.4,)"
+    _(subject.to_version('!=2.3.4.rc')).must_equal "(2.3.4.rc-SNAPSHOT,)"
+    _(subject.to_version('=2.3.4')).must_equal "[2.3.4,2.3.4.0.0.0.0.1)"
+    _(subject.to_version('=2.3.4.alpha')).must_equal "2.3.4.alpha"
+    _(subject.to_version('~>1.8.2')).must_equal "[1.8.2,1.8.99999]"
+    _(subject.to_version('~>1.8.2.beta')).must_equal "[1.8.2.beta-SNAPSHOT,1.8.99999]"
+    _(subject.to_version('~>1.8.2.beta123.12')).must_equal "[1.8.2.beta123.12-SNAPSHOT,1.8.99999]"
+    _(subject.to_version('~>1.8.2.1beta')).must_equal "[1.8.2.1beta-SNAPSHOT,1.8.99999]"
+    _(subject.to_version('~>1.8')).must_equal "[1.8,1.99999]"
+    _(subject.to_version('~>0')).must_equal "[0,99999]"
+    _(subject.to_version('>1.2')).must_equal "(1.2,)"
+    _(subject.to_version('>1.2.GA')).must_equal "(1.2.GA-SNAPSHOT,)"
+    _(subject.to_version('<1.2')).must_equal "[0,1.2)"
+    _(subject.to_version('<1.2.dev')).must_equal "[0,1.2.dev-SNAPSHOT)"
+    _(subject.to_version('>=1.2')).must_equal "[1.2,)"
+    _(subject.to_version('>=1.2.gamma')).must_equal "[1.2.gamma-SNAPSHOT,)"
+    _(subject.to_version('<=1.2')).must_equal "[0,1.2]"
+    _(subject.to_version('<=1.2.pre')).must_equal "[0,1.2.pre-SNAPSHOT]"
+    _(subject.to_version('>=1.2', '<2.0')).must_equal "[1.2,2.0)"
+    _(subject.to_version('>=1.2', '<=2.0')).must_equal "[1.2,2.0]"
+    _(subject.to_version('>1.2', '<2.0')).must_equal "(1.2,2.0)"
+    _(subject.to_version('>1.2', '<=2.0')).must_equal "(1.2,2.0]"
   end
-  
+
   it 'should keep maven version and ranges as they are' do
-    subject.to_version('1.2.3').must_equal "1.2.3"
-    subject.to_version('(1,2)').must_equal "(1,2)"
-    subject.to_version('[1,2)').must_equal "[1,2)"
-    subject.to_version('(1,2]').must_equal "(1,2]"
-    subject.to_version('[1,2]').must_equal "[1,2]"
+    _(subject.to_version('1.2.3')).must_equal "1.2.3"
+    _(subject.to_version('(1,2)')).must_equal "(1,2)"
+    _(subject.to_version('[1,2)')).must_equal "[1,2)"
+    _(subject.to_version('(1,2]')).must_equal "(1,2]"
+    _(subject.to_version('[1,2]')).must_equal "[1,2]"
   end
 
   it 'should keep maven snapshot version and ranges as they are' do
-    subject.to_version('1.2.3-SNAPSHOT').must_equal "1.2.3-SNAPSHOT"
-    subject.to_version('(1,2-SNAPSHOT)').must_equal "(1,2-SNAPSHOT)"
-    subject.to_version('[1-SNAPSHOT,2)').must_equal "[1-SNAPSHOT,2)"
-    subject.to_version('(1,2-SNAPSHOT]').must_equal "(1,2-SNAPSHOT]"
-    subject.to_version('[1-SNAPSHOT,2]').must_equal "[1-SNAPSHOT,2]"
+    _(subject.to_version('1.2.3-SNAPSHOT')).must_equal "1.2.3-SNAPSHOT"
+    _(subject.to_version('(1,2-SNAPSHOT)')).must_equal "(1,2-SNAPSHOT)"
+    _(subject.to_version('[1-SNAPSHOT,2)')).must_equal "[1-SNAPSHOT,2)"
+    _(subject.to_version('(1,2-SNAPSHOT]')).must_equal "(1,2-SNAPSHOT]"
+    _(subject.to_version('[1-SNAPSHOT,2]')).must_equal "[1-SNAPSHOT,2]"
   end
 
   it 'should convert pom of jar deps to maven coordinate' do
-    subject.to_coordinate('something "a:b"').must_be_nil
-    subject.to_coordinate('#jar "a:b"').must_be_nil
-    subject.to_coordinate('jar "a:b" # bla').must_equal "a:b:jar:[0,)"
-    subject.to_coordinate("pom 'b:c', '!=2.3.4'").must_equal "b:c:pom:(2.3.4,)"
-    subject.to_coordinate('jar "c:d", "2.3.4"').must_equal "c:d:jar:2.3.4"
-    subject.to_coordinate("jar 'd:e', '~>1.8.2'").must_equal "d:e:jar:[1.8.2,1.8.99999]"
-    subject.to_coordinate('pom "f:g", ">1.2", "<=2.0"').must_equal "f:g:pom:(1.2,2.0]"
-    subject.to_coordinate('pom "e:f", "[1.8,1.9.9)"').must_equal "e:f:pom:[1.8,1.9.9)"
-    subject.to_coordinate('pom "e:f", "(1.8,1.9.9)"').must_equal "e:f:pom:(1.8,1.9.9)"
-    subject.to_coordinate('pom "e:f", "[1.8, 1.9.9]"').must_equal "e:f:pom:[1.8,1.9.9]"
+    _(subject.to_coordinate('something "a:b"')).must_be_nil
+    _(subject.to_coordinate('#jar "a:b"')).must_be_nil
+    _(subject.to_coordinate('jar "a:b" # bla')).must_equal "a:b:jar:[0,)"
+    _(subject.to_coordinate("pom 'b:c', '!=2.3.4'")).must_equal "b:c:pom:(2.3.4,)"
+    _(subject.to_coordinate('jar "c:d", "2.3.4"')).must_equal "c:d:jar:2.3.4"
+    _(subject.to_coordinate("jar 'd:e', '~>1.8.2'")).must_equal "d:e:jar:[1.8.2,1.8.99999]"
+    _(subject.to_coordinate('pom "f:g", ">1.2", "<=2.0"')).must_equal "f:g:pom:(1.2,2.0]"
+    _(subject.to_coordinate('pom "e:f", "[1.8,1.9.9)"')).must_equal "e:f:pom:[1.8,1.9.9)"
+    _(subject.to_coordinate('pom "e:f", "(1.8,1.9.9)"')).must_equal "e:f:pom:(1.8,1.9.9)"
+    _(subject.to_coordinate('pom "e:f", "[1.8, 1.9.9]"')).must_equal "e:f:pom:[1.8,1.9.9]"
   end
 
   it 'should support classifiers' do
-    subject.to_coordinate('something "a:b:jdk15"').must_be_nil
-    subject.to_coordinate('#jar "a:b:jdk15"').must_be_nil
-    subject.to_coordinate('jar "a:b:jdk15" # bla').must_equal "a:b:jar:jdk15:[0,)"
-    subject.to_coordinate("pom 'b:c:jdk15', '!=2.3.4'").must_equal "b:c:pom:jdk15:(2.3.4,)"
-    subject.to_coordinate('jar "c:d:jdk15", "2.3.4"').must_equal "c:d:jar:jdk15:2.3.4"
-    subject.to_coordinate("jar 'd:e:jdk15', '~>1.8.2'").must_equal "d:e:jar:jdk15:[1.8.2,1.8.99999]"
-    subject.to_coordinate('pom "f:g:jdk15", ">1.2", "<=2.0"').must_equal "f:g:pom:jdk15:(1.2,2.0]"
-    subject.to_coordinate('pom "e:f:jdk15", "[1.8,1.9.9)"').must_equal "e:f:pom:jdk15:[1.8,1.9.9)"
-    subject.to_coordinate('pom "e:f:jdk15", "(1.8,1.9.9)"').must_equal "e:f:pom:jdk15:(1.8,1.9.9)"
-    subject.to_coordinate('pom "e:f:jdk15", "[1.8, 1.9.9]"').must_equal "e:f:pom:jdk15:[1.8,1.9.9]"
+    _(subject.to_coordinate('something "a:b:jdk15"')).must_be_nil
+    _(subject.to_coordinate('#jar "a:b:jdk15"')).must_be_nil
+    _(subject.to_coordinate('jar "a:b:jdk15" # bla')).must_equal "a:b:jar:jdk15:[0,)"
+    _(subject.to_coordinate("pom 'b:c:jdk15', '!=2.3.4'")).must_equal "b:c:pom:jdk15:(2.3.4,)"
+    _(subject.to_coordinate('jar "c:d:jdk15", "2.3.4"')).must_equal "c:d:jar:jdk15:2.3.4"
+    _(subject.to_coordinate("jar 'd:e:jdk15', '~>1.8.2'")).must_equal "d:e:jar:jdk15:[1.8.2,1.8.99999]"
+    _(subject.to_coordinate('pom "f:g:jdk15", ">1.2", "<=2.0"')).must_equal "f:g:pom:jdk15:(1.2,2.0]"
+    _(subject.to_coordinate('pom "e:f:jdk15", "[1.8,1.9.9)"')).must_equal "e:f:pom:jdk15:[1.8,1.9.9)"
+    _(subject.to_coordinate('pom "e:f:jdk15", "(1.8,1.9.9)"')).must_equal "e:f:pom:jdk15:(1.8,1.9.9)"
+    _(subject.to_coordinate('pom "e:f:jdk15", "[1.8, 1.9.9]"')).must_equal "e:f:pom:jdk15:[1.8,1.9.9]"
   end
 
   it 'supports declarations with scope' do
-    subject.to_split_coordinate_with_scope('jar rubygems:ruby-maven, ~> 3.1.1.0, :scope => :provided').must_equal [:provided, "rubygems", "ruby-maven", "jar", "[3.1.1.0,3.1.1.99999]"]
-    subject.to_split_coordinate_with_scope("jar 'rubygems:ruby-maven', '~> 3.1.1.0', :scope => :test").must_equal [:test, "rubygems", "ruby-maven", "jar", "[3.1.1.0,3.1.1.99999]"]
+    _(subject.to_split_coordinate_with_scope('jar rubygems:ruby-maven, ~> 3.1.1.0, :scope => :provided')).must_equal [:provided, "rubygems", "ruby-maven", "jar", "[3.1.1.0,3.1.1.99999]"]
+    _(subject.to_split_coordinate_with_scope("jar 'rubygems:ruby-maven', '~> 3.1.1.0', :scope => :test")).must_equal [:test, "rubygems", "ruby-maven", "jar", "[3.1.1.0,3.1.1.99999]"]
   end
 end

--- a/spec/dsl/gemspec_spec.rb
+++ b/spec/dsl/gemspec_spec.rb
@@ -30,21 +30,21 @@ describe Maven::Tools::DSL::Gemspec do
     subject.new parent
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( GemspecFile.read( 'maven-tools.xml', 'maven-tools'  ) )
+    _(xml).must_equal( GemspecFile.read( 'maven-tools.xml', 'maven-tools'  ) )
   end
 
   it 'evals maven_tools.gemspec from yaml' do
     subject.new parent, 'maven-tools.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( GemspecFile.read( 'maven-tools.xml', 'gemspec_spec' ) )
+    _(xml).must_equal( GemspecFile.read( 'maven-tools.xml', 'gemspec_spec' ) )
   end
 
   it 'evals gemspec with jar and pom dependencies' do
     subject.new parent, 'jars_and_poms.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( GemspecFile.read( 'jars_and_poms.xml',
+    _(xml).must_equal( GemspecFile.read( 'jars_and_poms.xml',
                                   'gemspec_spec' ) )
   end
 
@@ -52,7 +52,7 @@ describe Maven::Tools::DSL::Gemspec do
     subject.new parent, :name => 'jars_and_poms.gemspec', :include_jars => true
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( GemspecFile.read( 'jars_and_poms_include_jars.xml',
+    _(xml).must_equal( GemspecFile.read( 'jars_and_poms_include_jars.xml',
                                   'gemspec_spec' ) )
   end
 end

--- a/spec/dsl/gemspec_spec/jars_and_poms.xml
+++ b/spec/dsl/gemspec_spec/jars_and_poms.xml
@@ -1,9 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>gemspec_spec</artifactId>
-  <version>0.0.0</version>
-  <name>gemspec_spec</name>
   <properties>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
     <mavengem.wagon.version>1.0.3</mavengem.wagon.version>
@@ -15,33 +10,38 @@
       <version>1.6.4</version>
     </dependency>
     <dependency>
+      <type>pom</type>
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
       <version>1.7.16</version>
-      <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>org.jruby</groupId>
-      <artifactId>jruby</artifactId>
-      <version>1.7.16</version>
-      <classifier>noasm</classifier>
       <exclusions>
         <exclusion>
           <groupId>org.jruby</groupId>
           <artifactId>jruby-stdlib</artifactId>
         </exclusion>
       </exclusions>
+      <groupId>org.jruby</groupId>
+      <artifactId>jruby</artifactId>
+      <version>1.7.16</version>
+      <classifier>noasm</classifier>
     </dependency>
   </dependencies>
+  <modelVersion>4.0.0</modelVersion>
+  <name>gemspec_spec</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>gemspec_spec</artifactId>
+  <version>0.0.0</version>
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>jars_and_poms.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/spec/dsl/gemspec_spec/jars_and_poms_include_jars.xml
+++ b/spec/dsl/gemspec_spec/jars_and_poms_include_jars.xml
@@ -1,9 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>gemspec_spec</artifactId>
-  <version>0.0.0</version>
-  <name>gemspec_spec</name>
   <properties>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
     <mavengem.wagon.version>1.0.3</mavengem.wagon.version>
@@ -15,31 +10,34 @@
       <version>1.6.4</version>
     </dependency>
     <dependency>
+      <type>pom</type>
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
       <version>1.7.16</version>
-      <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>org.jruby</groupId>
-      <artifactId>jruby</artifactId>
-      <version>1.7.16</version>
-      <classifier>noasm</classifier>
       <exclusions>
         <exclusion>
           <groupId>org.jruby</groupId>
           <artifactId>jruby-stdlib</artifactId>
         </exclusion>
       </exclusions>
+      <groupId>org.jruby</groupId>
+      <artifactId>jruby</artifactId>
+      <version>1.7.16</version>
+      <classifier>noasm</classifier>
     </dependency>
   </dependencies>
+  <modelVersion>4.0.0</modelVersion>
+  <name>gemspec_spec</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>gemspec_spec</artifactId>
+  <version>0.0.0</version>
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <phase>generate-test-resources</phase>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
@@ -47,18 +45,20 @@
               <outputDirectory>lib</outputDirectory>
               <useRepositoryLayout>true</useRepositoryLayout>
             </configuration>
+            <phase>generate-test-resources</phase>
           </execution>
         </executions>
+        <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>jars_and_poms.gemspec</gemspec>
           <includeDependencies>true</includeDependencies>
           <useRepositoryLayout>true</useRepositoryLayout>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/spec/dsl/gemspec_spec/maven-tools.xml
+++ b/spec/dsl/gemspec_spec/maven-tools.xml
@@ -1,44 +1,80 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>BASEDIR</artifactId>
-  <version>0.0.0</version>
-  <name>BASEDIR</name>
   <properties>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
     <mavengem.wagon.version>1.0.3</mavengem.wagon.version>
   </properties>
   <dependencies>
     <dependency>
-      <groupId>rubygems</groupId>
-      <artifactId>virtus</artifactId>
-      <version>[1.0,1.99999]</version>
       <type>gem</type>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-container</artifactId>
+      <version>[0.7.2,0.7.99999]</version>
     </dependency>
     <dependency>
+      <type>gem</type>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-configurable</artifactId>
+      <version>[0.7.2,0.7.99999]</version>
+    </dependency>
+    <dependency>
+      <type>gem</type>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-core</artifactId>
+      <version>[0.6.0,0.6.99999]</version>
+    </dependency>
+    <dependency>
+      <type>gem</type>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-inflector</artifactId>
+      <version>[0.2.0,0.2.99999]</version>
+    </dependency>
+    <dependency>
+      <type>gem</type>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-types</artifactId>
+      <version>[1.5.1,1.5.99999]</version>
+    </dependency>\
+    <dependency>
+      <type>gem</type>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-struct</artifactId>
+      <version>[1.4.0,1.4.99999]</version>
+    </dependency>
+    <dependency>
+      <type>gem</type>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-struct-setters</artifactId>
+      <version>[0.4.0,0.4.99999]</version>
+    </dependency>
+    <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>rake</artifactId>
       <version>[10.0,10.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>minitest</artifactId>
       <version>[5.3,5.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
+  <modelVersion>4.0.0</modelVersion>
+  <name>BASEDIR</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>BASEDIR</artifactId>
+  <version>0.0.0</version>
   <build>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>maven-tools.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/spec/dsl/jarfile_lock_spec.rb
+++ b/spec/dsl/jarfile_lock_spec.rb
@@ -9,29 +9,29 @@ describe Maven::Tools::DSL::JarfileLock do
 
   it 'loads legacy Jarfile.lock' do
     lock = subject.new( base + '.legacy' )
-    lock.coordinates( :test ).size.must_equal 0
-    lock.coordinates.size.must_equal 52
+    _(lock.coordinates( :test ).size).must_equal 0
+    _(lock.coordinates.size).must_equal 52
   end
 
   it 'loads Jarfile.lock' do
     lock = subject.new( base )
-    lock.coordinates( :test ).size.must_equal 7
-    lock.coordinates.size.must_equal 45
+    _(lock.coordinates( :test ).size).must_equal 7
+    _(lock.coordinates.size).must_equal 45
   end
 
   it 'tests existence' do
     lock = subject.new( base )
     ( lock.coordinates( :test ) + lock.coordinates ).each do |c|
-      lock.exists?( c ).must_equal true
-      lock.exists?( c + ".bla" ).must_equal false
+      _(lock.exists?( c )).must_equal true
+      _(lock.exists?( c + ".bla" )).must_equal false
     end
   end
 
   it 'tests locked' do
     lock = subject.new( base )
     ( lock.coordinates( :test ) + lock.coordinates ).each do |c|
-      lock.locked?( c ).must_equal true
-      lock.locked?( c + ".bla" ).must_equal true
+      _(lock.locked?( c )).must_equal true
+      _(lock.locked?( c + ".bla" )).must_equal true
     end
   end
 
@@ -45,8 +45,8 @@ describe Maven::Tools::DSL::JarfileLock do
                               :runtime => [ 'huffle:puffle:321' ] } )
       lock.dump
       lock = subject.new( file )
-      lock.coordinates.must_equal ['huffle:puffle:321']
-      lock.coordinates( :test ).must_equal ['bla:blas:123']    
+      _(lock.coordinates).must_equal ['huffle:puffle:321']
+      _(lock.coordinates( :test )).must_equal ['bla:blas:123']
     ensure
       FileUtils.rm_f file_lock
     end
@@ -57,43 +57,43 @@ describe Maven::Tools::DSL::JarfileLock do
 
     lock.replace( { :test => [ 'bla:blas:123' ],
                     :runtime => [ 'huffle:puffle:321' ] } )
-    lock.coordinates.must_equal ['huffle:puffle:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.coordinates).must_equal ['huffle:puffle:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
 
     lock.replace( { :runtime => [ 'huffle:puffle:321' ] } )
-    lock.coordinates.must_equal ['huffle:puffle:321']
-    lock.coordinates( :test ).must_equal [] 
+    _(lock.coordinates).must_equal ['huffle:puffle:321']
+    _(lock.coordinates( :test )).must_equal []
 
     lock.replace( { :test => [ 'bla:blas:123' ]} )
-    lock.coordinates.must_equal []
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.coordinates).must_equal []
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
   end
 
   it 'can add missing data idempotent' do
     lock = subject.new( 'something' )
 
-    lock.update_unlocked( { :test => [ 'bla:blas:123' ],
-                            :runtime => [ 'huffle:puffle:321' ] } ).must_equal true
-    lock.update_unlocked( { :test => [ 'bla:blas:123' ],
-                            :runtime => [ 'huffle:puffle:321' ] } ).must_equal true
-    lock.coordinates.must_equal ['huffle:puffle:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.update_unlocked( { :test => [ 'bla:blas:123' ],
+                            :runtime => [ 'huffle:puffle:321' ] } )).must_equal true
+    _(lock.update_unlocked( { :test => [ 'bla:blas:123' ],
+                            :runtime => [ 'huffle:puffle:321' ] } )).must_equal true
+    _(lock.coordinates).must_equal ['huffle:puffle:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
 
-    lock.update_unlocked( { :runtime => [ 'huffle:puffle:321' ] } ).must_equal true
-    lock.coordinates.must_equal ['huffle:puffle:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.update_unlocked( { :runtime => [ 'huffle:puffle:321' ] } )).must_equal true
+    _(lock.coordinates).must_equal ['huffle:puffle:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
 
-    lock.update_unlocked( { :runtime => [ 'huffle:puffle2:321' ] } ).must_equal true
-    lock.coordinates.must_equal ['huffle:puffle:321', 'huffle:puffle2:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.update_unlocked( { :runtime => [ 'huffle:puffle2:321' ] } )).must_equal true
+    _(lock.coordinates).must_equal ['huffle:puffle:321', 'huffle:puffle2:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
 
-    lock.update_unlocked( { :test => [ 'bla:blas:123' ]} ).must_equal true
-    lock.coordinates.must_equal ['huffle:puffle:321', 'huffle:puffle2:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.update_unlocked( { :test => [ 'bla:blas:123' ]} )).must_equal true
+    _(lock.coordinates).must_equal ['huffle:puffle:321', 'huffle:puffle2:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
 
-    lock.update_unlocked( { :test => [ 'bla:bla2:123' ]} ).must_equal true
-    lock.coordinates.must_equal ['huffle:puffle:321', 'huffle:puffle2:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123', 'bla:bla2:123'] 
+    _(lock.update_unlocked( { :test => [ 'bla:bla2:123' ]} )).must_equal true
+    _(lock.coordinates).must_equal ['huffle:puffle:321', 'huffle:puffle2:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123', 'bla:bla2:123']
   end
 
   it 'fails add data on version conflict' do
@@ -102,17 +102,17 @@ describe Maven::Tools::DSL::JarfileLock do
     lock.replace( { :test => [ 'bla:blas:123' ],
                     :runtime => [ 'huffle:puffle:321' ] } )
 
-    lock.update_unlocked( { :test => [ 'bla:blas:1233' ],
-                            :runtime => [ 'huffle:puffle:3214' ] } ).must_equal false
-    lock.coordinates.must_equal ['huffle:puffle:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.update_unlocked( { :test => [ 'bla:blas:1233' ],
+                            :runtime => [ 'huffle:puffle:3214' ] } )).must_equal false
+    _(lock.coordinates).must_equal ['huffle:puffle:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
 
-    lock.update_unlocked( { :runtime => [ 'huffle:puffle:3214' ] } ).must_equal false
-    lock.coordinates.must_equal ['huffle:puffle:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.update_unlocked( { :runtime => [ 'huffle:puffle:3214' ] } )).must_equal false
+    _(lock.coordinates).must_equal ['huffle:puffle:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
 
-    lock.update_unlocked( { :test => [ 'bla:blas:1233' ]} ).must_equal false
-    lock.coordinates.must_equal ['huffle:puffle:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.update_unlocked( { :test => [ 'bla:blas:1233' ]} )).must_equal false
+    _(lock.coordinates).must_equal ['huffle:puffle:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
   end
 end

--- a/spec/dsl/profile_gemspec_spec.rb
+++ b/spec/dsl/profile_gemspec_spec.rb
@@ -34,7 +34,7 @@ describe Maven::Tools::DSL::ProfileGemspec do
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
     v = Maven::Tools::VERSION
     v += '-SNAPSHOT' if v =~ /.dev$/
-    xml.must_equal( ProfileGemspecFile.read( 'maven-tools.xml', 'maven-tools',
+    _(xml).must_equal( ProfileGemspecFile.read( 'maven-tools.xml', 'maven-tools',
                                   v ) )
   end
 
@@ -42,28 +42,28 @@ describe Maven::Tools::DSL::ProfileGemspec do
     subject.new parent, 'maven-tools.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( ProfileGemspecFile.read( 'maven-tools.xml', 'profile_gemspec_spec' ) )
+    _(xml).must_equal( ProfileGemspecFile.read( 'maven-tools.xml', 'profile_gemspec_spec' ) )
   end
 
   it 'evals maven_tools.gemspec from yaml no gem dependencies' do
     subject.new parent, 'maven-tools.gemspec', :no_gems => true
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( ProfileGemspecFile.read( 'no_gems.xml', 'gemspec_spec' ) )
+    _(xml).must_equal( ProfileGemspecFile.read( 'no_gems.xml', 'gemspec_spec' ) )
   end
 
   it 'evals snapshot.gemspec' do
     subject.new parent, 'snapshot.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( ProfileGemspecFile.read( 'snapshot.xml', 'snapshot', '1.a-SNAPSHOT' ) )
+    _(xml).must_equal( ProfileGemspecFile.read( 'snapshot.xml', 'snapshot', '1.a-SNAPSHOT' ) )
   end
 
   it 'evals gemspec with jar and pom dependencies' do
     subject.new parent, 'jars_and_poms.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( ProfileGemspecFile.read( 'jars_and_poms.xml',
+    _(xml).must_equal( ProfileGemspecFile.read( 'jars_and_poms.xml',
                                   'gemspec_spec' ) )
   end
 
@@ -71,7 +71,7 @@ describe Maven::Tools::DSL::ProfileGemspec do
     subject.new parent, :name => 'jars_and_poms.gemspec', :include_jars => true
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( ProfileGemspecFile.read( 'jars_and_poms_include_jars.xml',
+    _(xml).must_equal( ProfileGemspecFile.read( 'jars_and_poms_include_jars.xml',
                                              'gemspec_spec' ) )
   end
 
@@ -79,6 +79,6 @@ describe Maven::Tools::DSL::ProfileGemspec do
     subject.new parent, 'unknown_license.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( ProfileGemspecFile.read( 'unknown_license.xml', 'gemspec_spec' ) )
+    _(xml).must_equal( ProfileGemspecFile.read( 'unknown_license.xml', 'gemspec_spec' ) )
   end
 end

--- a/spec/dsl/profile_gemspec_spec/jars_and_poms.xml
+++ b/spec/dsl/profile_gemspec_spec/jars_and_poms.xml
@@ -1,9 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>profile_gemspec_spec</artifactId>
-  <version>0.0.0</version>
-  <name>profile_gemspec_spec</name>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -16,22 +11,22 @@
       <version>1.6.4</version>
     </dependency>
     <dependency>
+      <type>pom</type>
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
       <version>1.7.16</version>
-      <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>org.jruby</groupId>
-      <artifactId>jruby</artifactId>
-      <version>1.7.16</version>
-      <classifier>noasm</classifier>
       <exclusions>
         <exclusion>
           <groupId>org.jruby</groupId>
           <artifactId>jruby-stdlib</artifactId>
         </exclusion>
       </exclusions>
+      <groupId>org.jruby</groupId>
+      <artifactId>jruby</artifactId>
+      <version>1.7.16</version>
+      <classifier>noasm</classifier>
     </dependency>
   </dependencies>
   <repositories>
@@ -40,6 +35,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>profile_gemspec_spec</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>profile_gemspec_spec</artifactId>
+  <version>0.0.0</version>
   <build>
     <extensions>
       <extension>
@@ -50,12 +50,12 @@
     </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>jars_and_poms.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/spec/dsl/profile_gemspec_spec/jars_and_poms_include_jars.xml
+++ b/spec/dsl/profile_gemspec_spec/jars_and_poms_include_jars.xml
@@ -1,9 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>profile_gemspec_spec</artifactId>
-  <version>0.0.0</version>
-  <name>profile_gemspec_spec</name>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -16,22 +11,22 @@
       <version>1.6.4</version>
     </dependency>
     <dependency>
+      <type>pom</type>
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
       <version>1.7.16</version>
-      <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>org.jruby</groupId>
-      <artifactId>jruby</artifactId>
-      <version>1.7.16</version>
-      <classifier>noasm</classifier>
       <exclusions>
         <exclusion>
           <groupId>org.jruby</groupId>
           <artifactId>jruby-stdlib</artifactId>
         </exclusion>
       </exclusions>
+      <groupId>org.jruby</groupId>
+      <artifactId>jruby</artifactId>
+      <version>1.7.16</version>
+      <classifier>noasm</classifier>
     </dependency>
   </dependencies>
   <repositories>
@@ -40,6 +35,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>profile_gemspec_spec</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>profile_gemspec_spec</artifactId>
+  <version>0.0.0</version>
   <build>
     <extensions>
       <extension>
@@ -50,10 +50,8 @@
     </extensions>
     <plugins>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <phase>generate-test-resources</phase>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
@@ -61,18 +59,20 @@
               <outputDirectory>lib</outputDirectory>
               <useRepositoryLayout>true</useRepositoryLayout>
             </configuration>
+            <phase>generate-test-resources</phase>
           </execution>
         </executions>
+        <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>jars_and_poms.gemspec</gemspec>
           <includeDependencies>true</includeDependencies>
           <useRepositoryLayout>true</useRepositoryLayout>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/spec/dsl/profile_gemspec_spec/maven-tools.xml
+++ b/spec/dsl/profile_gemspec_spec/maven-tools.xml
@@ -1,9 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>BASEDIR</artifactId>
-  <version>0.0.0</version>
-  <name>BASEDIR</name>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -11,24 +6,60 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>rubygems</groupId>
-      <artifactId>virtus</artifactId>
-      <version>[1.0,1.99999]</version>
       <type>gem</type>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-container</artifactId>
+      <version>[0.7.2,0.7.99999]</version>
     </dependency>
     <dependency>
+      <type>gem</type>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-configurable</artifactId>
+      <version>[0.7.2,0.7.99999]</version>
+    </dependency>
+    <dependency>
+      <type>gem</type>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-core</artifactId>
+      <version>[0.6.0,0.6.99999]</version>
+    </dependency>
+    <dependency>
+      <type>gem</type>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-inflector</artifactId>
+      <version>[0.2.0,0.2.99999]</version>
+    </dependency>
+    <dependency>
+      <type>gem</type>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-types</artifactId>
+      <version>[1.5.1,1.5.99999]</version>
+    </dependency>\
+    <dependency>
+      <type>gem</type>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-struct</artifactId>
+      <version>[1.4.0,1.4.99999]</version>
+    </dependency>
+    <dependency>
+      <type>gem</type>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-struct-setters</artifactId>
+      <version>[0.4.0,0.4.99999]</version>
+    </dependency>
+    <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>rake</artifactId>
       <version>[10.0,10.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>minitest</artifactId>
       <version>[5.3,5.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>
@@ -37,6 +68,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>BASEDIR</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>BASEDIR</artifactId>
+  <version>0.0.0</version>
   <build>
     <extensions>
       <extension>
@@ -47,12 +83,12 @@
     </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>maven-tools.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/spec/dsl/profile_gemspec_spec/no_gems.xml
+++ b/spec/dsl/profile_gemspec_spec/no_gems.xml
@@ -1,9 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>profile_gemspec_spec</artifactId>
-  <version>0.0.0</version>
-  <name>profile_gemspec_spec</name>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -15,6 +10,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>profile_gemspec_spec</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>profile_gemspec_spec</artifactId>
+  <version>0.0.0</version>
   <build>
     <extensions>
       <extension>
@@ -25,12 +25,12 @@
     </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>maven-tools.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/spec/dsl/profile_gemspec_spec/snapshot.xml
+++ b/spec/dsl/profile_gemspec_spec/snapshot.xml
@@ -1,9 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>profile_gemspec_spec</artifactId>
-  <version>0.0.0</version>
-  <name>profile_gemspec_spec</name>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -15,6 +10,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>profile_gemspec_spec</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>profile_gemspec_spec</artifactId>
+  <version>0.0.0</version>
   <build>
     <extensions>
       <extension>
@@ -25,12 +25,12 @@
     </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>snapshot.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/spec/dsl/profile_gemspec_spec/unknown_license.xml
+++ b/spec/dsl/profile_gemspec_spec/unknown_license.xml
@@ -1,9 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>profile_gemspec_spec</artifactId>
-  <version>0.0.0</version>
-  <name>profile_gemspec_spec</name>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -15,6 +10,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>profile_gemspec_spec</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>profile_gemspec_spec</artifactId>
+  <version>0.0.0</version>
   <build>
     <extensions>
       <extension>
@@ -25,12 +25,12 @@
     </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>unknown_license.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/spec/dsl/project_gemspec_spec.rb
+++ b/spec/dsl/project_gemspec_spec.rb
@@ -34,7 +34,7 @@ describe Maven::Tools::DSL::ProjectGemspec do
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
     v = Maven::Tools::VERSION
     v += '-SNAPSHOT' if v =~ /.dev$/
-    xml.must_equal( XmlFile.read( 'maven-tools.xml', 'maven-tools',
+    _(xml).must_equal( XmlFile.read( 'maven-tools.xml', 'maven-tools',
                                   v ) )
   end
 
@@ -42,35 +42,35 @@ describe Maven::Tools::DSL::ProjectGemspec do
     subject.new parent, 'maven-tools.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'maven-tools.xml', 'gemspec_spec' ) )
+    _(xml).must_equal( XmlFile.read( 'maven-tools.xml', 'gemspec_spec' ) )
   end
 
   it 'evals maven_tools.gemspec from yaml with profile' do
     subject.new parent, 'maven-tools.gemspec', :profile => :hidden
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'profile.xml', 'gemspec_spec' ) )
+    _(xml).must_equal( XmlFile.read( 'profile.xml', 'gemspec_spec' ) )
   end
 
   it 'evals maven_tools.gemspec from yaml no gem dependencies' do
     subject.new parent, 'maven-tools.gemspec', :no_gems => true
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'no_gems.xml', 'gemspec_spec' ) )
+    _(xml).must_equal( XmlFile.read( 'no_gems.xml', 'gemspec_spec' ) )
   end
 
   it 'evals snapshot.gemspec' do
     subject.new parent, 'snapshot.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'snapshot.xml', 'snapshot', '1.a-SNAPSHOT' ) )
+    _(xml).must_equal( XmlFile.read( 'snapshot.xml', 'snapshot', '1.a-SNAPSHOT' ) )
   end
 
   it 'evals gemspec with jar and pom dependencies' do
     subject.new parent, 'jars_and_poms.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'jars_and_poms.xml',
+    _(xml).must_equal( XmlFile.read( 'jars_and_poms.xml',
                                   'gemspec_spec' ) )
   end
 
@@ -78,7 +78,7 @@ describe Maven::Tools::DSL::ProjectGemspec do
     subject.new parent, :name => 'jars_and_poms.gemspec', :include_jars => true
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'jars_and_poms_include_jars.xml',
+    _(xml).must_equal( XmlFile.read( 'jars_and_poms_include_jars.xml',
                                   'gemspec_spec' ) )
   end
 
@@ -91,7 +91,7 @@ describe Maven::Tools::DSL::ProjectGemspec do
     subject.new parent, :name => 'extended.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'extended.xml',
+    _(xml).must_equal( XmlFile.read( 'extended.xml',
                                   'gemspec_spec' ) )
   end
 
@@ -99,6 +99,6 @@ describe Maven::Tools::DSL::ProjectGemspec do
     subject.new parent, :name => 'unknown_license.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'unknown_license.xml', 'gemspec_spec') )
+    _(xml).must_equal( XmlFile.read( 'unknown_license.xml', 'gemspec_spec') )
   end
 end

--- a/spec/dsl/project_gemspec_spec/extended.xml
+++ b/spec/dsl/project_gemspec_spec/extended.xml
@@ -1,12 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>maven-tools</artifactId>
-  <version>123</version>
-  <packaging>gem</packaging>
-  <name>helpers for maven related tasks</name>
-  <url>http://github.com/torquebox/maven-tools</url>
-  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
   <licenses>
     <license>
       <name>MIT</name>
@@ -20,10 +12,6 @@
       <email>m.kristian@web.de</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/torquebox/maven-tools.git</connection>
-    <url>http://github.com/torquebox/maven-tools</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -36,22 +24,22 @@
       <version>1.6.4</version>
     </dependency>
     <dependency>
+      <type>pom</type>
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
       <version>1.7.16</version>
-      <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>org.jruby</groupId>
-      <artifactId>jruby</artifactId>
-      <version>1.7.16</version>
-      <classifier>noasm</classifier>
       <exclusions>
         <exclusion>
           <groupId>org.jruby</groupId>
           <artifactId>jruby-stdlib</artifactId>
         </exclusion>
       </exclusions>
+      <groupId>org.jruby</groupId>
+      <artifactId>jruby</artifactId>
+      <version>1.7.16</version>
+      <classifier>noasm</classifier>
     </dependency>
   </dependencies>
   <repositories>
@@ -64,6 +52,11 @@
       <url>http://localhost/repo</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>helpers for maven related tasks</name>
+  <groupId>rubygems</groupId>
+  <artifactId>maven-tools</artifactId>
+  <version>123</version>
   <build>
     <extensions>
       <extension>
@@ -77,16 +70,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>extended.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
+  <url>http://github.com/torquebox/maven-tools</url>
+  <scm>
+    <connection>https://github.com/torquebox/maven-tools.git</connection>
+    <url>http://github.com/torquebox/maven-tools</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/dsl/project_gemspec_spec/jars_and_poms.xml
+++ b/spec/dsl/project_gemspec_spec/jars_and_poms.xml
@@ -1,12 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>maven-tools</artifactId>
-  <version>123</version>
-  <packaging>gem</packaging>
-  <name>helpers for maven related tasks</name>
-  <url>http://github.com/torquebox/maven-tools</url>
-  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
   <licenses>
     <license>
       <name>MIT</name>
@@ -20,10 +12,6 @@
       <email>m.kristian@web.de</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/torquebox/maven-tools.git</connection>
-    <url>http://github.com/torquebox/maven-tools</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -36,22 +24,22 @@
       <version>1.6.4</version>
     </dependency>
     <dependency>
+      <type>pom</type>
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
       <version>1.7.16</version>
-      <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>org.jruby</groupId>
-      <artifactId>jruby</artifactId>
-      <version>1.7.16</version>
-      <classifier>noasm</classifier>
       <exclusions>
         <exclusion>
           <groupId>org.jruby</groupId>
           <artifactId>jruby-stdlib</artifactId>
         </exclusion>
       </exclusions>
+      <groupId>org.jruby</groupId>
+      <artifactId>jruby</artifactId>
+      <version>1.7.16</version>
+      <classifier>noasm</classifier>
     </dependency>
   </dependencies>
   <repositories>
@@ -60,6 +48,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>helpers for maven related tasks</name>
+  <groupId>rubygems</groupId>
+  <artifactId>maven-tools</artifactId>
+  <version>123</version>
   <build>
     <extensions>
       <extension>
@@ -73,16 +66,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>jars_and_poms.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
+  <url>http://github.com/torquebox/maven-tools</url>
+  <scm>
+    <connection>https://github.com/torquebox/maven-tools.git</connection>
+    <url>http://github.com/torquebox/maven-tools</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/dsl/project_gemspec_spec/jars_and_poms_include_jars.xml
+++ b/spec/dsl/project_gemspec_spec/jars_and_poms_include_jars.xml
@@ -1,12 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>maven-tools</artifactId>
-  <version>123</version>
-  <packaging>gem</packaging>
-  <name>helpers for maven related tasks</name>
-  <url>http://github.com/torquebox/maven-tools</url>
-  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
   <licenses>
     <license>
       <name>MIT</name>
@@ -20,10 +12,6 @@
       <email>m.kristian@web.de</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/torquebox/maven-tools.git</connection>
-    <url>http://github.com/torquebox/maven-tools</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -36,22 +24,22 @@
       <version>1.6.4</version>
     </dependency>
     <dependency>
+      <type>pom</type>
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
       <version>1.7.16</version>
-      <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>org.jruby</groupId>
-      <artifactId>jruby</artifactId>
-      <version>1.7.16</version>
-      <classifier>noasm</classifier>
       <exclusions>
         <exclusion>
           <groupId>org.jruby</groupId>
           <artifactId>jruby-stdlib</artifactId>
         </exclusion>
       </exclusions>
+      <groupId>org.jruby</groupId>
+      <artifactId>jruby</artifactId>
+      <version>1.7.16</version>
+      <classifier>noasm</classifier>
     </dependency>
   </dependencies>
   <repositories>
@@ -60,6 +48,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>helpers for maven related tasks</name>
+  <groupId>rubygems</groupId>
+  <artifactId>maven-tools</artifactId>
+  <version>123</version>
   <build>
     <extensions>
       <extension>
@@ -73,13 +66,10 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <phase>generate-test-resources</phase>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
@@ -87,19 +77,29 @@
               <outputDirectory>lib</outputDirectory>
               <useRepositoryLayout>true</useRepositoryLayout>
             </configuration>
+            <phase>generate-test-resources</phase>
           </execution>
         </executions>
+        <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>jars_and_poms.gemspec</gemspec>
           <includeDependencies>true</includeDependencies>
           <useRepositoryLayout>true</useRepositoryLayout>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
+  <url>http://github.com/torquebox/maven-tools</url>
+  <scm>
+    <connection>https://github.com/torquebox/maven-tools.git</connection>
+    <url>http://github.com/torquebox/maven-tools</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/dsl/project_gemspec_spec/maven-tools.xml
+++ b/spec/dsl/project_gemspec_spec/maven-tools.xml
@@ -1,12 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>maven-tools</artifactId>
-  <version>VERSION</version>
-  <packaging>gem</packaging>
-  <name>helpers for maven related tasks</name>
-  <url>http://github.com/torquebox/maven-tools</url>
-  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
   <licenses>
     <license>
       <name>MIT</name>
@@ -20,10 +12,6 @@
       <email>m.kristian@web.de</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/torquebox/maven-tools.git</connection>
-    <url>http://github.com/torquebox/maven-tools</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -31,24 +19,24 @@
   </properties>
   <dependencies>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>virtus</artifactId>
       <version>[1.0,1.99999]</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>rake</artifactId>
       <version>[10.0,10.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>minitest</artifactId>
       <version>[5.3,5.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>
@@ -57,6 +45,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>helpers for maven related tasks</name>
+  <groupId>rubygems</groupId>
+  <artifactId>maven-tools</artifactId>
+  <version>VERSION</version>
   <build>
     <extensions>
       <extension>
@@ -70,16 +63,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>maven-tools.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
+  <url>http://github.com/torquebox/maven-tools</url>
+  <scm>
+    <connection>https://github.com/torquebox/maven-tools.git</connection>
+    <url>http://github.com/torquebox/maven-tools</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/dsl/project_gemspec_spec/no_gems.xml
+++ b/spec/dsl/project_gemspec_spec/no_gems.xml
@@ -1,12 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>maven-tools</artifactId>
-  <version>VERSION</version>
-  <packaging>gem</packaging>
-  <name>helpers for maven related tasks</name>
-  <url>http://github.com/torquebox/maven-tools</url>
-  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
   <licenses>
     <license>
       <name>MIT</name>
@@ -20,10 +12,6 @@
       <email>m.kristian@web.de</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/torquebox/maven-tools.git</connection>
-    <url>http://github.com/torquebox/maven-tools</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,6 +23,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>helpers for maven related tasks</name>
+  <groupId>rubygems</groupId>
+  <artifactId>maven-tools</artifactId>
+  <version>VERSION</version>
   <build>
     <extensions>
       <extension>
@@ -48,16 +41,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>maven-tools.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
+  <url>http://github.com/torquebox/maven-tools</url>
+  <scm>
+    <connection>https://github.com/torquebox/maven-tools.git</connection>
+    <url>http://github.com/torquebox/maven-tools</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/dsl/project_gemspec_spec/profile.xml
+++ b/spec/dsl/project_gemspec_spec/profile.xml
@@ -1,12 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>maven-tools</artifactId>
-  <version>VERSION</version>
-  <packaging>gem</packaging>
-  <name>helpers for maven related tasks</name>
-  <url>http://github.com/torquebox/maven-tools</url>
-  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
   <licenses>
     <license>
       <name>MIT</name>
@@ -20,10 +12,6 @@
       <email>m.kristian@web.de</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/torquebox/maven-tools.git</connection>
-    <url>http://github.com/torquebox/maven-tools</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,6 +23,38 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <profiles>
+    <profile>
+      <dependencies>
+        <dependency>
+          <type>gem</type>
+          <groupId>rubygems</groupId>
+          <artifactId>virtus</artifactId>
+          <version>[1.0,1.99999]</version>
+        </dependency>
+        <dependency>
+          <scope>test</scope>
+          <type>gem</type>
+          <groupId>rubygems</groupId>
+          <artifactId>rake</artifactId>
+          <version>[10.0,10.99999]</version>
+        </dependency>
+        <dependency>
+          <scope>test</scope>
+          <type>gem</type>
+          <groupId>rubygems</groupId>
+          <artifactId>minitest</artifactId>
+          <version>[5.3,5.99999]</version>
+        </dependency>
+      </dependencies>
+      <id>hidden</id>
+    </profile>
+  </profiles>
+  <modelVersion>4.0.0</modelVersion>
+  <name>helpers for maven related tasks</name>
+  <groupId>rubygems</groupId>
+  <artifactId>maven-tools</artifactId>
+  <version>VERSION</version>
   <build>
     <extensions>
       <extension>
@@ -48,43 +68,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>maven-tools.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
-  <profiles>
-    <profile>
-      <id>hidden</id>
-      <dependencies>
-        <dependency>
-          <groupId>rubygems</groupId>
-          <artifactId>virtus</artifactId>
-          <version>[1.0,1.99999]</version>
-          <type>gem</type>
-        </dependency>
-        <dependency>
-          <groupId>rubygems</groupId>
-          <artifactId>rake</artifactId>
-          <version>[10.0,10.99999]</version>
-          <type>gem</type>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>rubygems</groupId>
-          <artifactId>minitest</artifactId>
-          <version>[5.3,5.99999]</version>
-          <type>gem</type>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
+  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
+  <url>http://github.com/torquebox/maven-tools</url>
+  <scm>
+    <connection>https://github.com/torquebox/maven-tools.git</connection>
+    <url>http://github.com/torquebox/maven-tools</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/dsl/project_gemspec_spec/snapshot.xml
+++ b/spec/dsl/project_gemspec_spec/snapshot.xml
@@ -1,12 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>maven-tools</artifactId>
-  <version>VERSION</version>
-  <packaging>gem</packaging>
-  <name>helpers for maven related tasks</name>
-  <url>http://github.com/torquebox/maven-tools</url>
-  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
   <licenses>
     <license>
       <name>MIT</name>
@@ -20,10 +12,6 @@
       <email>m.kristian@web.de</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/torquebox/maven-tools.git</connection>
-    <url>http://github.com/torquebox/maven-tools</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,6 +23,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>helpers for maven related tasks</name>
+  <groupId>rubygems</groupId>
+  <artifactId>maven-tools</artifactId>
+  <version>VERSION</version>
   <build>
     <extensions>
       <extension>
@@ -48,16 +41,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>snapshot.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
+  <url>http://github.com/torquebox/maven-tools</url>
+  <scm>
+    <connection>https://github.com/torquebox/maven-tools.git</connection>
+    <url>http://github.com/torquebox/maven-tools</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/dsl/project_gemspec_spec/unknown_license.xml
+++ b/spec/dsl/project_gemspec_spec/unknown_license.xml
@@ -1,12 +1,4 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>maven-tools</artifactId>
-  <version>123</version>
-  <packaging>gem</packaging>
-  <name>helpers for maven related tasks</name>
-  <url>http://github.com/torquebox/maven-tools</url>
-  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
   <licenses>
     <license>
       <name>unknown</name>
@@ -18,10 +10,6 @@
       <email>m.kristian@web.de</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/torquebox/maven-tools.git</connection>
-    <url>http://github.com/torquebox/maven-tools</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -33,6 +21,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>helpers for maven related tasks</name>
+  <groupId>rubygems</groupId>
+  <artifactId>maven-tools</artifactId>
+  <version>123</version>
   <build>
     <extensions>
       <extension>
@@ -46,16 +39,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>unknown_license.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
+  <url>http://github.com/torquebox/maven-tools</url>
+  <scm>
+    <connection>https://github.com/torquebox/maven-tools.git</connection>
+    <url>http://github.com/torquebox/maven-tools</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemfile/pom.xml
+++ b/spec/gemfile/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0149</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -57,6 +45,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0149</version>
   <build>
     <extensions>
       <extension>
@@ -70,16 +63,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemfile/pom.xml
+++ b/spec/gemfile/pom.xml
@@ -25,8 +25,8 @@
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>virtus</artifactId>
-      <version>[0,)</version>
       <type>gem</type>
+      <version>[0,)</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/spec/gemfile_include_jars/pom.xml
+++ b/spec/gemfile_include_jars/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0149</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -51,6 +39,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0149</version>
   <build>
     <extensions>
       <extension>
@@ -64,13 +57,10 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <phase>generate-test-resources</phase>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
@@ -78,19 +68,29 @@
               <outputDirectory>lib</outputDirectory>
               <useRepositoryLayout>true</useRepositoryLayout>
             </configuration>
+            <phase>generate-test-resources</phase>
           </execution>
         </executions>
+        <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
           <includeDependencies>true</includeDependencies>
           <useRepositoryLayout>true</useRepositoryLayout>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemfile_with_access_to_model/pom.xml
+++ b/spec/gemfile_with_access_to_model/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -40,6 +28,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0</version>
   <build>
     <extensions>
       <extension>
@@ -53,16 +46,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemfile_with_custom_source/pom.xml
+++ b/spec/gemfile_with_custom_source/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,17 +23,17 @@
   </properties>
   <dependencies>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>thor</artifactId>
       <version>[0.14.6,2.0)</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>rake</artifactId>
       <version>[10.0,10.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>
@@ -54,8 +42,12 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0</version>
   <build>
-    <sourceDirectory>src/java</sourceDirectory>
     <extensions>
       <extension>
         <groupId>org.torquebox.mojo</groupId>
@@ -68,27 +60,24 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
         <executions>
           <execution>
-            <phase>prepare-package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
+            <phase>prepare-package</phase>
           </execution>
         </executions>
         <configuration>
           <outputDirectory>mylib</outputDirectory>
           <finalName>bouncy-castle-java</finalName>
         </configuration>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>2.4</version>
         <configuration>
           <filesets>
             <fileset>
@@ -100,15 +89,26 @@
             </fileset>
           </filesets>
         </configuration>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
+    <sourceDirectory>src/java</sourceDirectory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemfile_with_custom_source_and_custom_jarname/pom.xml
+++ b/spec/gemfile_with_custom_source_and_custom_jarname/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,17 +23,17 @@
   </properties>
   <dependencies>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>thor</artifactId>
       <version>[0.14.6,2.0)</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>rake</artifactId>
       <version>[10.0,10.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>
@@ -54,8 +42,12 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0</version>
   <build>
-    <sourceDirectory>src/java</sourceDirectory>
     <extensions>
       <extension>
         <groupId>org.torquebox.mojo</groupId>
@@ -68,27 +60,24 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
         <executions>
           <execution>
-            <phase>prepare-package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
+            <phase>prepare-package</phase>
           </execution>
         </executions>
         <configuration>
           <outputDirectory>lib</outputDirectory>
           <finalName>green</finalName>
         </configuration>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>2.4</version>
         <configuration>
           <filesets>
             <fileset>
@@ -100,15 +89,26 @@
             </fileset>
           </filesets>
         </configuration>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
+    <sourceDirectory>src/java</sourceDirectory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemfile_with_extras/pom.xml
+++ b/spec/gemfile_with_extras/pom.xml
@@ -61,14 +61,13 @@
     </extensions>
     <resources>
       <resource>
-        <targetPath>${basedir}/lib</targetPath>
-        <directory>../../lib/ruby/shared/</directory>
         <includes>
           <include>bouncy-castle-java.rb</include>
         </includes>
+        <directory>../../lib/ruby/shared/</directory>
+        <targetPath>${basedir}/lib</targetPath>
       </resource>
     </resources>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
         <executions>
@@ -96,12 +95,8 @@
         <version>${jruby.plugins.version}</version>
       </plugin>
       <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>2.5</version>
         <executions>
           <execution>
-            <id>clean-lib</id>
-            <phase>clean</phase>
             <goals>
               <goal>clean</goal>
             </goals>
@@ -113,10 +108,15 @@
               </filesets>
               <failOnError>false</failOnError>
             </configuration>
+            <id>clean-lib</id>
+            <phase>clean</phase>
           </execution>
         </executions>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.5</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
   <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>

--- a/spec/gemfile_with_extras/pom.xml
+++ b/spec/gemfile_with_extras/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0149</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -53,6 +41,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0149</version>
   <build>
     <extensions>
       <extension>
@@ -78,10 +71,8 @@
     <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <phase>generate-test-resources</phase>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
@@ -89,18 +80,20 @@
               <outputDirectory>lib</outputDirectory>
               <useRepositoryLayout>true</useRepositoryLayout>
             </configuration>
+            <phase>generate-test-resources</phase>
           </execution>
         </executions>
+        <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
           <includeDependencies>true</includeDependencies>
           <useRepositoryLayout>true</useRepositoryLayout>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
@@ -125,4 +118,11 @@
       </plugin>
     </plugins>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemfile_with_groups/pom.xml
+++ b/spec/gemfile_with_groups/pom.xml
@@ -10,11 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>gemfile_with_groups</artifactId>
-  <version>0.0.0</version>
-  <name>gemfile_with_groups</name>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -63,6 +58,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>gemfile_with_groups</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>gemfile_with_groups</artifactId>
+  <version>0.0.0</version>
   <build>
     <extensions>
       <extension>
@@ -71,21 +71,21 @@
         <version>${mavengem.wagon.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <executions>
           <execution>
-            <id>install gems</id>
             <goals>
               <goal>initialize</goal>
             </goals>
+            <id>install gems</id>
           </execution>
         </executions>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
 </project>

--- a/spec/gemfile_with_groups_and_lockfile/pom.xml
+++ b/spec/gemfile_with_groups_and_lockfile/pom.xml
@@ -10,11 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>gemfile_with_groups_and_lockfile</artifactId>
-  <version>0.0.0</version>
-  <name>gemfile_with_groups_and_lockfile</name>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -26,39 +21,8 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
-  <build>
-    <extensions>
-      <extension>
-        <groupId>org.torquebox.mojo</groupId>
-        <artifactId>mavengem-wagon</artifactId>
-        <version>${mavengem.wagon.version}</version>
-      </extension>
-    </extensions>
-    <directory>${basedir}/pkg</directory>
-    <plugins>
-      <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
-        <executions>
-          <execution>
-            <id>install gems</id>
-            <goals>
-              <goal>initialize</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
   <profiles>
     <profile>
-      <id>gemfile</id>
-      <activation>
-        <file>
-          <missing>Gemfile.lock</missing>
-        </file>
-      </activation>
       <dependencies>
         <dependency>
           <groupId>rubygems</groupId>
@@ -75,6 +39,12 @@
           <scope>provided</scope>
         </dependency>
       </dependencies>
+      <id>gemfile</id>
+      <activation>
+        <file>
+          <missing>Gemfile.lock</missing>
+        </file>
+      </activation>
     </profile>
     <profile>
       <id>gemfile_lock</id>
@@ -86,13 +56,8 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>de.saumya.mojo</groupId>
-            <artifactId>gem-maven-plugin</artifactId>
-            <version>${jruby.plugins.version}</version>
             <executions>
               <execution>
-                <id>install gem sets for provided</id>
-                <phase>initialize</phase>
                 <goals>
                   <goal>sets</goal>
                 </goals>
@@ -109,10 +74,10 @@
                     <yajl-ruby>1.1.0</yajl-ruby>
                   </gems>
                 </configuration>
+                <id>install gem sets for provided</id>
+                <phase>initialize</phase>
               </execution>
               <execution>
-                <id>install gem sets for test</id>
-                <phase>initialize</phase>
                 <goals>
                   <goal>sets</goal>
                 </goals>
@@ -126,11 +91,46 @@
                     <rspec-mocks>2.13.1</rspec-mocks>
                   </gems>
                 </configuration>
+                <id>install gem sets for test</id>
+                <phase>initialize</phase>
               </execution>
             </executions>
+            <groupId>de.saumya.mojo</groupId>
+            <artifactId>gem-maven-plugin</artifactId>
+            <version>${jruby.plugins.version}</version>
           </plugin>
         </plugins>
       </build>
     </profile>
   </profiles>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>gemfile_with_groups_and_lockfile</artifactId>
+  <version>0.0.0</version>
+  <name>gemfile_with_groups_and_lockfile</name>
+  <build>
+    <extensions>
+      <extension>
+        <groupId>org.torquebox.mojo</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>${mavengem.wagon.version}</version>
+      </extension>
+    </extensions>
+    <plugins>
+      <plugin>
+        <executions>
+          <execution>
+            <id>install gems</id>
+            <goals>
+              <goal>initialize</goal>
+            </goals>
+          </execution>
+        </executions>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
+      </plugin>
+    </plugins>
+    <directory>${basedir}/pkg</directory>
+  </build>
 </project>

--- a/spec/gemfile_with_groups_and_lockfile/pom.xml
+++ b/spec/gemfile_with_groups_and_lockfile/pom.xml
@@ -104,10 +104,10 @@
     </profile>
   </profiles>
   <modelVersion>4.0.0</modelVersion>
+  <name>gemfile_with_groups_and_lockfile</name>
   <groupId>no_group_id_given</groupId>
   <artifactId>gemfile_with_groups_and_lockfile</artifactId>
   <version>0.0.0</version>
-  <name>gemfile_with_groups_and_lockfile</name>
   <build>
     <extensions>
       <extension>
@@ -120,10 +120,10 @@
       <plugin>
         <executions>
           <execution>
-            <id>install gems</id>
             <goals>
               <goal>initialize</goal>
             </goals>
+            <id>install gems</id>
           </execution>
         </executions>
         <groupId>de.saumya.mojo</groupId>

--- a/spec/gemfile_with_jars_lock/pom.xml
+++ b/spec/gemfile_with_jars_lock/pom.xml
@@ -23,12 +23,6 @@
   </repositories>
   <profiles>
     <profile>
-      <id>Jars.lock</id>
-      <activation>
-        <file>
-          <exists>Jars.lock</exists>
-        </file>
-      </activation>
       <dependencies>
         <dependency>
           <groupId>org.bouncycastle</groupId>
@@ -43,6 +37,12 @@
           <scope>compile</scope>
         </dependency>
       </dependencies>
+      <id>Jars.lock</id>
+      <activation>
+        <file>
+          <exists>Jars.lock</exists>
+        </file>
+      </activation>
     </profile>
   </profiles>
   <modelVersion>4.0.0</modelVersion>

--- a/spec/gemfile_with_jars_lock/pom.xml
+++ b/spec/gemfile_with_jars_lock/pom.xml
@@ -10,11 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>gemfile_with_jars_lock</artifactId>
-  <version>0.0.0</version>
-  <name>gemfile_with_jars_lock</name>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -26,31 +21,6 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
-  <build>
-    <extensions>
-      <extension>
-        <groupId>org.torquebox.mojo</groupId>
-        <artifactId>mavengem-wagon</artifactId>
-        <version>${mavengem.wagon.version}</version>
-      </extension>
-    </extensions>
-    <directory>${basedir}/pkg</directory>
-    <plugins>
-      <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
-        <executions>
-          <execution>
-            <id>install gems</id>
-            <goals>
-              <goal>initialize</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
   <profiles>
     <profile>
       <id>Jars.lock</id>
@@ -75,4 +45,34 @@
       </dependencies>
     </profile>
   </profiles>
+  <modelVersion>4.0.0</modelVersion>
+  <name>gemfile_with_jars_lock</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>gemfile_with_jars_lock</artifactId>
+  <version>0.0.0</version>
+  <build>
+    <extensions>
+      <extension>
+        <groupId>org.torquebox.mojo</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>${mavengem.wagon.version}</version>
+      </extension>
+    </extensions>
+    <plugins>
+      <plugin>
+        <executions>
+          <execution>
+            <goals>
+              <goal>initialize</goal>
+            </goals>
+            <id>install gems</id>
+          </execution>
+        </executions>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
+      </plugin>
+    </plugins>
+    <directory>${basedir}/pkg</directory>
+  </build>
 </project>

--- a/spec/gemfile_with_lock/pom.xml
+++ b/spec/gemfile_with_lock/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0149</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -51,31 +39,6 @@
       <url>mavengem:http://localhost:8081/gems</url>
     </repository>
   </repositories>
-  <build>
-    <extensions>
-      <extension>
-        <groupId>org.torquebox.mojo</groupId>
-        <artifactId>mavengem-wagon</artifactId>
-        <version>${mavengem.wagon.version}</version>
-      </extension>
-      <extension>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-extension</artifactId>
-        <version>${jruby.plugins.version}</version>
-      </extension>
-    </extensions>
-    <directory>${basedir}/pkg</directory>
-    <plugins>
-      <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
-        <configuration>
-          <gemspec>bouncy-castle-java.gemspec</gemspec>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
   <profiles>
     <profile>
       <id>gemfile</id>
@@ -86,27 +49,35 @@
       </activation>
       <dependencies>
         <dependency>
+          <type>gem</type>
           <groupId>rubygems</groupId>
           <artifactId>virtus</artifactId>
           <version>[0,)</version>
-          <type>gem</type>
         </dependency>
         <dependency>
+          <type>gem</type>
           <groupId>rubygems</groupId>
           <artifactId>rake</artifactId>
           <version>[10.2,10.99999]</version>
-          <type>gem</type>
         </dependency>
         <dependency>
+          <scope>test</scope>
+          <type>gem</type>
           <groupId>rubygems</groupId>
           <artifactId>rspec</artifactId>
           <version>[2.11,2.99999]</version>
-          <type>gem</type>
-          <scope>test</scope>
         </dependency>
       </dependencies>
     </profile>
     <profile>
+      <dependencies>
+        <dependency>
+          <groupId>rubygems</groupId>
+          <artifactId>bundler</artifactId>
+          <version>1.10.5</version>
+          <type>gem</type>
+        </dependency>
+      </dependencies>
       <id>gemfile_lock</id>
       <activation>
         <file>
@@ -116,13 +87,8 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>de.saumya.mojo</groupId>
-            <artifactId>gem-maven-plugin</artifactId>
-            <version>${jruby.plugins.version}</version>
             <executions>
               <execution>
-                <id>install gem sets for compile</id>
-                <phase>initialize</phase>
                 <goals>
                   <goal>sets</goal>
                 </goals>
@@ -139,10 +105,10 @@
                     <rake>10.3.0</rake>
                   </gems>
                 </configuration>
+                <id>install gem sets for compile</id>
+                <phase>initialize</phase>
               </execution>
               <execution>
-                <id>install gem sets for test</id>
-                <phase>initialize</phase>
                 <goals>
                   <goal>sets</goal>
                 </goals>
@@ -156,19 +122,53 @@
                     <rspec-mocks>2.14.6</rspec-mocks>
                   </gems>
                 </configuration>
+                <id>install gem sets for test</id>
+                <phase>initialize</phase>
               </execution>
             </executions>
+            <groupId>de.saumya.mojo</groupId>
+            <artifactId>gem-maven-plugin</artifactId>
+            <version>${jruby.plugins.version}</version>
           </plugin>
         </plugins>
       </build>
-      <dependencies>
-        <dependency>
-          <groupId>rubygems</groupId>
-          <artifactId>bundler</artifactId>
-          <version>1.10.5</version>
-          <type>gem</type>
-        </dependency>
-      </dependencies>
     </profile>
   </profiles>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0149</version>
+  <build>
+    <extensions>
+      <extension>
+        <groupId>org.torquebox.mojo</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>${mavengem.wagon.version}</version>
+      </extension>
+      <extension>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-extension</artifactId>
+        <version>${jruby.plugins.version}</version>
+      </extension>
+    </extensions>
+    <plugins>
+      <plugin>
+        <configuration>
+          <gemspec>bouncy-castle-java.gemspec</gemspec>
+        </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
+      </plugin>
+    </plugins>
+    <directory>${basedir}/pkg</directory>
+  </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemfile_with_lock/pom.xml
+++ b/spec/gemfile_with_lock/pom.xml
@@ -41,17 +41,11 @@
   </repositories>
   <profiles>
     <profile>
-      <id>gemfile</id>
-      <activation>
-        <file>
-          <missing>Gemfile.lock</missing>
-        </file>
-      </activation>
       <dependencies>
         <dependency>
-          <type>gem</type>
           <groupId>rubygems</groupId>
           <artifactId>virtus</artifactId>
+          <type>gem</type>
           <version>[0,)</version>
         </dependency>
         <dependency>
@@ -68,6 +62,12 @@
           <version>[2.11,2.99999]</version>
         </dependency>
       </dependencies>
+      <id>gemfile</id>
+      <activation>
+        <file>
+          <missing>Gemfile.lock</missing>
+        </file>
+      </activation>
     </profile>
     <profile>
       <dependencies>

--- a/spec/gemfile_with_path/pom.xml
+++ b/spec/gemfile_with_path/pom.xml
@@ -10,11 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>gemfile_with_path</artifactId>
-  <version>0.0.0</version>
-  <name>gemfile_with_path</name>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -24,8 +19,8 @@
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>rake</artifactId>
-      <version>[0,)</version>
       <type>gem</type>
+      <version>[0,)</version>
     </dependency>
     <dependency>
       <groupId>rubygems</groupId>
@@ -41,6 +36,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>gemfile_with_path</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>gemfile_with_path</artifactId>
+  <version>0.0.0</version>
   <build>
     <extensions>
       <extension>
@@ -49,21 +49,16 @@
         <version>${mavengem.wagon.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <executions>
           <execution>
-            <id>install gems</id>
             <goals>
               <goal>initialize</goal>
             </goals>
+            <id>install gems</id>
           </execution>
           <execution>
-            <id>bundle install</id>
             <goals>
               <goal>exec</goal>
             </goals>
@@ -71,9 +66,14 @@
               <filename>bundle</filename>
               <args>install</args>
             </configuration>
+            <id>bundle install</id>
           </execution>
         </executions>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
 </project>

--- a/spec/gemfile_with_platforms/pom.xml
+++ b/spec/gemfile_with_platforms/pom.xml
@@ -10,11 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>gemfile_with_platforms</artifactId>
-  <version>0.0.0</version>
-  <name>gemfile_with_platforms</name>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -40,6 +35,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>gemfile_with_platforms</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>gemfile_with_platforms</artifactId>
+  <version>0.0.0</version>
   <build>
     <extensions>
       <extension>
@@ -48,21 +48,21 @@
         <version>${mavengem.wagon.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <executions>
           <execution>
-            <id>install gems</id>
             <goals>
               <goal>initialize</goal>
             </goals>
+            <id>install gems</id>
           </execution>
         </executions>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
 </project>

--- a/spec/gemfile_with_source/pom.xml
+++ b/spec/gemfile_with_source/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0149</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -61,6 +49,11 @@
       <url>mavengem:https://example.com</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0149</version>
   <build>
     <extensions>
       <extension>
@@ -74,27 +67,24 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
         <executions>
           <execution>
-            <phase>prepare-package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
+            <phase>prepare-package</phase>
           </execution>
         </executions>
         <configuration>
           <outputDirectory>mylib</outputDirectory>
           <finalName>bouncy-castle-java</finalName>
         </configuration>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>2.4</version>
         <configuration>
           <filesets>
             <fileset>
@@ -106,15 +96,25 @@
             </fileset>
           </filesets>
         </configuration>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemfile_with_source_and_custom_jarname/pom.xml
+++ b/spec/gemfile_with_source_and_custom_jarname/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,17 +23,17 @@
   </properties>
   <dependencies>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>thor</artifactId>
       <version>[0.14.6,2.0)</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>rake</artifactId>
       <version>[10.0,10.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>
@@ -54,6 +42,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0</version>
   <build>
     <extensions>
       <extension>
@@ -67,27 +60,24 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
         <executions>
           <execution>
-            <phase>prepare-package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
+            <phase>prepare-package</phase>
           </execution>
         </executions>
         <configuration>
           <outputDirectory>mylib</outputDirectory>
           <finalName>green</finalName>
         </configuration>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>2.4</version>
         <configuration>
           <filesets>
             <fileset>
@@ -99,15 +89,25 @@
             </fileset>
           </filesets>
         </configuration>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemfile_with_source_and_no_jar/pom.xml
+++ b/spec/gemfile_with_source_and_no_jar/pom.xml
@@ -72,8 +72,8 @@
     </plugins>
     <directory>${basedir}/pkg</directory>
   </build>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
   <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
   <scm>
     <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
     <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>

--- a/spec/gemfile_with_source_and_no_jar/pom.xml
+++ b/spec/gemfile_with_source_and_no_jar/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,17 +23,17 @@
   </properties>
   <dependencies>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>thor</artifactId>
       <version>[0.14.6,2.0)</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>rake</artifactId>
       <version>[10.0,10.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>
@@ -54,6 +42,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0</version>
   <build>
     <extensions>
       <extension>
@@ -67,16 +60,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemfile_with_test_group/pom.xml
+++ b/spec/gemfile_with_test_group/pom.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>gemfile_with_test_group</artifactId>
-  <version>0.0.0</version>
-  <name>gemfile_with_test_group</name>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -17,31 +12,6 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
-  <build>
-    <extensions>
-      <extension>
-        <groupId>org.torquebox.mojo</groupId>
-        <artifactId>mavengem-wagon</artifactId>
-        <version>${mavengem.wagon.version}</version>
-      </extension>
-    </extensions>
-    <directory>${basedir}/pkg</directory>
-    <plugins>
-      <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
-        <executions>
-          <execution>
-            <id>install gems</id>
-            <goals>
-              <goal>initialize</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
   <profiles>
     <profile>
       <id>gemfile</id>
@@ -88,81 +58,81 @@
           <type>gem</type>
         </dependency>
         <dependency>
+          <scope>test</scope>
+          <type>gem</type>
           <groupId>rubygems</groupId>
           <artifactId>codeclimate-test-reporter</artifactId>
           <version>[0,)</version>
-          <type>gem</type>
-          <scope>test</scope>
         </dependency>
         <dependency>
+          <scope>test</scope>
+          <type>gem</type>
           <groupId>rubygems</groupId>
           <artifactId>rspec-mocks</artifactId>
           <version>[2.14.1,2.14.99999]</version>
-          <type>gem</type>
-          <scope>test</scope>
         </dependency>
         <dependency>
+          <scope>test</scope>
+          <type>gem</type>
           <groupId>rubygems</groupId>
           <artifactId>rspec</artifactId>
           <version>[2.14.1,2.14.99999]</version>
-          <type>gem</type>
-          <scope>test</scope>
         </dependency>
         <dependency>
+          <scope>test</scope>
+          <type>gem</type>
           <groupId>rubygems</groupId>
           <artifactId>simplecov</artifactId>
           <version>[0.8.2,0.8.99999]</version>
-          <type>gem</type>
-          <scope>test</scope>
         </dependency>
         <dependency>
+          <scope>test</scope>
+          <type>gem</type>
           <groupId>rubygems</groupId>
           <artifactId>thor</artifactId>
           <version>[0.18.1,0.18.99999]</version>
-          <type>gem</type>
-          <scope>test</scope>
         </dependency>
         <dependency>
+          <scope>test</scope>
+          <type>gem</type>
           <groupId>rubygems</groupId>
           <artifactId>vcr</artifactId>
           <version>[2.8.0,2.8.99999]</version>
-          <type>gem</type>
-          <scope>test</scope>
         </dependency>
         <dependency>
+          <scope>test</scope>
+          <type>gem</type>
           <groupId>rubygems</groupId>
           <artifactId>webmock</artifactId>
           <version>[1.16.0,1.16.99999]</version>
-          <type>gem</type>
-          <scope>test</scope>
         </dependency>
         <dependency>
+          <scope>test</scope>
+          <type>gem</type>
           <groupId>rubygems</groupId>
           <artifactId>fake_sqs</artifactId>
           <version>[0.1.0,0.1.99999]</version>
-          <type>gem</type>
-          <scope>test</scope>
         </dependency>
         <dependency>
+          <scope>test</scope>
+          <type>gem</type>
           <groupId>rubygems</groupId>
           <artifactId>rack-test</artifactId>
           <version>[0.6.2,0.6.99999]</version>
-          <type>gem</type>
-          <scope>test</scope>
         </dependency>
         <dependency>
+          <scope>test</scope>
+          <type>gem</type>
           <groupId>rubygems</groupId>
           <artifactId>database_cleaner</artifactId>
           <version>[1.2.0,1.2.99999]</version>
-          <type>gem</type>
-          <scope>test</scope>
         </dependency>
         <dependency>
+          <scope>test</scope>
+          <type>gem</type>
           <groupId>rubygems</groupId>
           <artifactId>shoulda-matchers</artifactId>
           <version>[2.6.1,2.6.99999]</version>
-          <type>gem</type>
-          <scope>test</scope>
         </dependency>
       </dependencies>
     </profile>
@@ -176,13 +146,8 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>de.saumya.mojo</groupId>
-            <artifactId>gem-maven-plugin</artifactId>
-            <version>${jruby.plugins.version}</version>
             <executions>
               <execution>
-                <id>install gem sets for compile</id>
-                <phase>initialize</phase>
                 <goals>
                   <goal>sets</goal>
                 </goals>
@@ -221,10 +186,10 @@
                     <equalizer>0.0.9</equalizer>
                   </gems>
                 </configuration>
+                <id>install gem sets for compile</id>
+                <phase>initialize</phase>
               </execution>
               <execution>
-                <id>install gem sets for test</id>
-                <phase>initialize</phase>
                 <goals>
                   <goal>sets</goal>
                 </goals>
@@ -255,11 +220,46 @@
                     <shoulda-matchers>2.6.1</shoulda-matchers>
                   </gems>
                 </configuration>
+                <id>install gem sets for test</id>
+                <phase>initialize</phase>
               </execution>
             </executions>
+            <groupId>de.saumya.mojo</groupId>
+            <artifactId>gem-maven-plugin</artifactId>
+            <version>${jruby.plugins.version}</version>
           </plugin>
         </plugins>
       </build>
     </profile>
   </profiles>
+  <modelVersion>4.0.0</modelVersion>
+  <name>gemfile_with_test_group</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>gemfile_with_test_group</artifactId>
+  <version>0.0.0</version>
+  <build>
+    <extensions>
+      <extension>
+        <groupId>org.torquebox.mojo</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>${mavengem.wagon.version}</version>
+      </extension>
+    </extensions>
+    <plugins>
+      <plugin>
+        <executions>
+          <execution>
+            <id>install gems</id>
+            <goals>
+              <goal>initialize</goal>
+            </goals>
+          </execution>
+        </executions>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
+      </plugin>
+    </plugins>
+    <directory>${basedir}/pkg</directory>
+  </build>
 </project>

--- a/spec/gemfile_with_two_sources/pom.xml
+++ b/spec/gemfile_with_two_sources/pom.xml
@@ -10,11 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>gemfile_with_two_sources</artifactId>
-  <version>0.0.0</version>
-  <name>gemfile_with_two_sources</name>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -30,6 +25,11 @@
       <url>mavengem:http://github.com/rubygems</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>gemfile_with_two_sources</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>gemfile_with_two_sources</artifactId>
+  <version>0.0.0</version>
   <build>
     <extensions>
       <extension>
@@ -38,21 +38,21 @@
         <version>${mavengem.wagon.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <executions>
           <execution>
-            <id>install gems</id>
             <goals>
               <goal>initialize</goal>
             </goals>
+            <id>install gems</id>
           </execution>
         </executions>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
 </project>

--- a/spec/gemfile_without_gemspec/pom.xml
+++ b/spec/gemfile_without_gemspec/pom.xml
@@ -10,11 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>gemfile_without_gemspec</artifactId>
-  <version>0.0.0</version>
-  <name>gemfile_without_gemspec</name>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -24,8 +19,8 @@
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>virtus</artifactId>
-      <version>[0,)</version>
       <type>gem</type>
+      <version>[0,)</version>
     </dependency>
   </dependencies>
   <repositories>
@@ -34,6 +29,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>gemfile_without_gemspec</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>gemfile_without_gemspec</artifactId>
+  <version>0.0.0</version>
   <build>
     <extensions>
       <extension>
@@ -42,21 +42,21 @@
         <version>${mavengem.wagon.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <executions>
           <execution>
-            <id>install gems</id>
             <goals>
               <goal>initialize</goal>
             </goals>
+            <id>install gems</id>
           </execution>
         </executions>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
 </project>

--- a/spec/gemspec/pom.xml
+++ b/spec/gemspec/pom.xml
@@ -10,14 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0149</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <licenses>
     <license>
       <name>EPL-1.0</name>
@@ -41,10 +33,6 @@
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -68,6 +56,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0149</version>
   <build>
     <extensions>
       <extension>
@@ -81,16 +74,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemspec_dependencies_spec.rb
+++ b/spec/gemspec_dependencies_spec.rb
@@ -6,8 +6,8 @@ describe Maven::Tools::GemspecDependencies do
   let( :spec ) do
     Gem::Specification.new do |s|
       s.add_dependency 'thor', '>= 0.14.6', '< 2.0'
-      s.add_dependency 'maven-tools', "~> 0.32.3" 
-      s.add_development_dependency 'minitest', '~> 5.0'  
+      s.add_dependency 'maven-tools', "~> 0.32.3"
+      s.add_development_dependency 'minitest', '~> 5.0'
       s.add_development_dependency 'rake', '~> 10.0'
       s.requirements << 'jar sdas:das:tes, 123'
       s.requirements << 'jar sdas:das, 123'
@@ -21,11 +21,11 @@ describe Maven::Tools::GemspecDependencies do
       s.requirements << 'jar "de.sdas.asd:das", "blub", 123,"[fds:fre, ferf:de]"'
     end
   end
-  
-  subject { Maven::Tools::GemspecDependencies.new( spec ) } 
+
+  subject { Maven::Tools::GemspecDependencies.new( spec ) }
 
   it 'should setup artifact' do
-    _(subject.runtime).must_equal ["rubygems:thor:[0.14.6,2.0", "rubygems:maven-tools:[0.32.3,0.32.99999]"]
+    _(subject.runtime).must_equal ["rubygems:thor:[0.14.6,2.0)", "rubygems:maven-tools:[0.32.3,0.32.99999]"]
     _(subject.development).must_equal ["rubygems:minitest:[5.0,5.99999]", "rubygems:rake:[10.0,10.99999]"]
     _(subject.java_runtime).must_equal [ ["sdas", "das", "jar", "tes", "123"],
                            ["sdas", "das", "jar", "123"],

--- a/spec/gemspec_dependencies_spec.rb
+++ b/spec/gemspec_dependencies_spec.rb
@@ -25,9 +25,9 @@ describe Maven::Tools::GemspecDependencies do
   subject { Maven::Tools::GemspecDependencies.new( spec ) } 
 
   it 'should setup artifact' do
-    subject.runtime.must_equal ["rubygems:thor:[0.14.6,2.0)", "rubygems:maven-tools:[0.32.3,0.32.99999]"]
-    subject.development.must_equal ["rubygems:minitest:[5.0,5.99999]", "rubygems:rake:[10.0,10.99999]"]
-    subject.java_runtime.must_equal [ ["sdas", "das", "jar", "tes", "123"],
+    _(subject.runtime).must_equal ["rubygems:thor:[0.14.6,2.0", "rubygems:maven-tools:[0.32.3,0.32.99999]"]
+    _(subject.development).must_equal ["rubygems:minitest:[5.0,5.99999]", "rubygems:rake:[10.0,10.99999]"]
+    _(subject.java_runtime).must_equal [ ["sdas", "das", "jar", "tes", "123"],
                            ["sdas", "das", "jar", "123"],
                            ["sdas.asd", "das", "jar", "123", ["fds:fre"]],
                            ["sdas.asd", "das", "jar", "bla", "123", ["fds:fre", "ferf:de"]],
@@ -37,7 +37,7 @@ describe Maven::Tools::GemspecDependencies do
                            ["de.sdas.asd", "das", "jar", "123", ["fds:fre"]],
                            ["de.sdas.asd", "das", "jar", "bla", "123", ["fds:fre", "ferf:de"]],
                            ["de.sdas.asd", "das", "jar", "blub", "123", ["fds:fre","ferf:de"]] ]
-    subject.java_dependencies.must_equal [ [:compile, "sdas", "das", "jar", "tes", "123"],
+    _(subject.java_dependencies).must_equal [ [:compile, "sdas", "das", "jar", "tes", "123"],
                            [:compile, "sdas", "das", "jar", "123"],
                            [:compile, "sdas.asd", "das", "jar", "123", ["fds:fre"]],
                            [:compile, "sdas.asd", "das", "jar", "bla", "123", ["fds:fre", "ferf:de"]],

--- a/spec/gemspec_in_profile/pom.xml
+++ b/spec/gemspec_in_profile/pom.xml
@@ -10,35 +10,8 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>gemspec_in_profile</artifactId>
-  <version>0.0.0</version>
-  <name>gemspec_in_profile</name>
-  <build>
-    <extensions>
-      <extension>
-        <groupId>org.torquebox.mojo</groupId>
-        <artifactId>mavengem-wagon</artifactId>
-        <version>${mavengem.wagon.version}</version>
-      </extension>
-    </extensions>
-  </build>
   <profiles>
     <profile>
-      <id>gem</id>
-      <build>
-        <plugins>
-          <plugin>
-            <configuration>
-              <gemspec>bouncy-castle-java.gemspec</gemspec>
-            </configuration>
-            <groupId>de.saumya.mojo</groupId>
-            <artifactId>gem-maven-plugin</artifactId>
-            <version>${jruby.plugins.version}</version>
-          </plugin>
-        </plugins>
-      </build>
       <properties>
         <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
         <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -62,6 +35,33 @@
           <url>mavengem:https://rubygems.org</url>
         </repository>
       </repositories>
+      <id>gem</id>
+      <build>
+        <plugins>
+          <plugin>
+            <configuration>
+              <gemspec>bouncy-castle-java.gemspec</gemspec>
+            </configuration>
+            <groupId>de.saumya.mojo</groupId>
+            <artifactId>gem-maven-plugin</artifactId>
+            <version>${jruby.plugins.version}</version>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
+  <modelVersion>4.0.0</modelVersion>
+  <name>gemspec_in_profile</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>gemspec_in_profile</artifactId>
+  <version>0.0.0</version>
+  <build>
+    <extensions>
+      <extension>
+        <groupId>org.torquebox.mojo</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>${mavengem.wagon.version}</version>
+      </extension>
+    </extensions>
+  </build>
 </project>

--- a/spec/gemspec_in_profile/pom.xml
+++ b/spec/gemspec_in_profile/pom.xml
@@ -30,12 +30,12 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>de.saumya.mojo</groupId>
-            <artifactId>gem-maven-plugin</artifactId>
-            <version>${jruby.plugins.version}</version>
             <configuration>
               <gemspec>bouncy-castle-java.gemspec</gemspec>
             </configuration>
+            <groupId>de.saumya.mojo</groupId>
+            <artifactId>gem-maven-plugin</artifactId>
+            <version>${jruby.plugins.version}</version>
           </plugin>
         </plugins>
       </build>

--- a/spec/gemspec_include_jars/pom.xml
+++ b/spec/gemspec_include_jars/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0149</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -51,6 +39,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0149</version>
   <build>
     <extensions>
       <extension>
@@ -64,13 +57,10 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <phase>generate-test-resources</phase>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
@@ -78,19 +68,29 @@
               <outputDirectory>lib</outputDirectory>
               <useRepositoryLayout>true</useRepositoryLayout>
             </configuration>
+            <phase>generate-test-resources</phase>
           </execution>
         </executions>
+        <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
           <includeDependencies>true</includeDependencies>
           <useRepositoryLayout>true</useRepositoryLayout>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemspec_no_rubygems_repo/pom.xml
+++ b/spec/gemspec_no_rubygems_repo/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.1</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,13 +23,18 @@
   </properties>
   <dependencies>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>minitest</artifactId>
       <version>[4.4,4.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.1</version>
   <build>
     <extensions>
       <extension>
@@ -55,16 +48,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemspec_prerelease/pom.xml
+++ b/spec/gemspec_prerelease/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.beta.1-SNAPSHOT</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,11 +23,11 @@
   </properties>
   <dependencies>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>minitest</artifactId>
       <version>[4.4,4.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>
@@ -48,6 +36,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.beta.1-SNAPSHOT</version>
   <build>
     <extensions>
       <extension>
@@ -61,16 +54,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemspec_prerelease_snapshot/pom.xml
+++ b/spec/gemspec_prerelease_snapshot/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.beta.1-SNAPSHOT</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,11 +23,11 @@
   </properties>
   <dependencies>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>minitest</artifactId>
       <version>[4.4,4.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>
@@ -48,6 +36,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.beta.1-SNAPSHOT</version>
   <build>
     <extensions>
       <extension>
@@ -61,16 +54,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemspec_with_access_to_model/pom.xml
+++ b/spec/gemspec_with_access_to_model/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -40,6 +28,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0</version>
   <build>
     <extensions>
       <extension>
@@ -53,16 +46,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemspec_with_custom_source/pom.xml
+++ b/spec/gemspec_with_custom_source/pom.xml
@@ -48,7 +48,6 @@
   <artifactId>bouncy-castle-java</artifactId>
   <version>1.5.0</version>
   <build>
-    <sourceDirectory>src/java</sourceDirectory>
     <extensions>
       <extension>
         <groupId>org.torquebox.mojo</groupId>
@@ -103,6 +102,7 @@
       </plugin>
     </plugins>
     <directory>${basedir}/pkg</directory>
+    <sourceDirectory>src/java</sourceDirectory>
   </build>
   <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>

--- a/spec/gemspec_with_custom_source/pom.xml
+++ b/spec/gemspec_with_custom_source/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,17 +23,17 @@
   </properties>
   <dependencies>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>thor</artifactId>
       <version>[0.14.6,2.0)</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>rake</artifactId>
       <version>[10.0,10.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>
@@ -54,6 +42,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0</version>
   <build>
     <sourceDirectory>src/java</sourceDirectory>
     <extensions>
@@ -68,27 +61,24 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
         <executions>
           <execution>
-            <phase>prepare-package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
+            <phase>prepare-package</phase>
           </execution>
         </executions>
         <configuration>
           <outputDirectory>mylib</outputDirectory>
           <finalName>bouncy-castle-java</finalName>
         </configuration>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>2.4</version>
         <configuration>
           <filesets>
             <fileset>
@@ -100,15 +90,25 @@
             </fileset>
           </filesets>
         </configuration>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemspec_with_custom_source_and_custom_jarname/pom.xml
+++ b/spec/gemspec_with_custom_source_and_custom_jarname/pom.xml
@@ -48,7 +48,6 @@
   <artifactId>bouncy-castle-java</artifactId>
   <version>1.5.0</version>
   <build>
-    <sourceDirectory>src/java</sourceDirectory>
     <extensions>
       <extension>
         <groupId>org.torquebox.mojo</groupId>
@@ -103,6 +102,7 @@
       </plugin>
     </plugins>
     <directory>${basedir}/pkg</directory>
+    <sourceDirectory>src/java</sourceDirectory>
   </build>
   <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>

--- a/spec/gemspec_with_custom_source_and_custom_jarname/pom.xml
+++ b/spec/gemspec_with_custom_source_and_custom_jarname/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,17 +23,17 @@
   </properties>
   <dependencies>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>thor</artifactId>
       <version>[0.14.6,2.0)</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>rake</artifactId>
       <version>[10.0,10.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>
@@ -54,6 +42,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0</version>
   <build>
     <sourceDirectory>src/java</sourceDirectory>
     <extensions>
@@ -68,27 +61,24 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
         <executions>
           <execution>
-            <phase>prepare-package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
+            <phase>prepare-package</phase>
           </execution>
         </executions>
         <configuration>
           <outputDirectory>lib</outputDirectory>
           <finalName>green</finalName>
         </configuration>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>2.4</version>
         <configuration>
           <filesets>
             <fileset>
@@ -100,15 +90,25 @@
             </fileset>
           </filesets>
         </configuration>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemspec_with_extras/pom.xml
+++ b/spec/gemspec_with_extras/pom.xml
@@ -61,14 +61,13 @@
     </extensions>
     <resources>
       <resource>
-        <targetPath>${basedir}/lib</targetPath>
-        <directory>../../lib/ruby/shared/</directory>
         <includes>
           <include>bouncy-castle-java.rb</include>
         </includes>
+        <directory>../../lib/ruby/shared/</directory>
+        <targetPath>${basedir}/lib</targetPath>
       </resource>
     </resources>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
         <executions>
@@ -96,12 +95,8 @@
         <version>${jruby.plugins.version}</version>
       </plugin>
       <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>2.5</version>
         <executions>
           <execution>
-            <id>clean-lib</id>
-            <phase>clean</phase>
             <goals>
               <goal>clean</goal>
             </goals>
@@ -113,10 +108,15 @@
               </filesets>
               <failOnError>false</failOnError>
             </configuration>
+            <id>clean-lib</id>
+            <phase>clean</phase>
           </execution>
         </executions>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.5</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
   <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>

--- a/spec/gemspec_with_extras/pom.xml
+++ b/spec/gemspec_with_extras/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0149</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -53,6 +41,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0149</version>
   <build>
     <extensions>
       <extension>
@@ -78,10 +71,8 @@
     <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <phase>generate-test-resources</phase>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
@@ -89,18 +80,20 @@
               <outputDirectory>lib</outputDirectory>
               <useRepositoryLayout>true</useRepositoryLayout>
             </configuration>
+            <phase>generate-test-resources</phase>
           </execution>
         </executions>
+        <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
           <includeDependencies>true</includeDependencies>
           <useRepositoryLayout>true</useRepositoryLayout>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
@@ -125,4 +118,11 @@
       </plugin>
     </plugins>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemspec_with_jar_dependencies/pom.xml
+++ b/spec/gemspec_with_jar_dependencies/pom.xml
@@ -10,14 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <licenses>
     <license>
       <name>EPL-1.0</name>
@@ -41,10 +33,6 @@
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -69,6 +57,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0</version>
   <build>
     <extensions>
       <extension>
@@ -82,16 +75,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemspec_with_jars_lock/pom.xml
+++ b/spec/gemspec_with_jars_lock/pom.xml
@@ -10,14 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0149</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <licenses>
     <license>
       <name>EPL-1.0</name>
@@ -41,10 +33,6 @@
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -63,39 +51,8 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
-  <build>
-    <extensions>
-      <extension>
-        <groupId>org.torquebox.mojo</groupId>
-        <artifactId>mavengem-wagon</artifactId>
-        <version>${mavengem.wagon.version}</version>
-      </extension>
-      <extension>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-extension</artifactId>
-        <version>${jruby.plugins.version}</version>
-      </extension>
-    </extensions>
-    <directory>${basedir}/pkg</directory>
-    <plugins>
-      <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
-        <configuration>
-          <gemspec>bouncy-castle-java.gemspec</gemspec>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
   <profiles>
     <profile>
-      <id>Jars.lock</id>
-      <activation>
-        <file>
-          <exists>Jars.lock</exists>
-        </file>
-      </activation>
       <dependencies>
         <dependency>
           <groupId>org.bouncycastle</groupId>
@@ -110,6 +67,49 @@
           <scope>compile</scope>
         </dependency>
       </dependencies>
+      <id>Jars.lock</id>
+      <activation>
+        <file>
+          <exists>Jars.lock</exists>
+        </file>
+      </activation>
     </profile>
   </profiles>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0149</version>
+  <build>
+    <extensions>
+      <extension>
+        <groupId>org.torquebox.mojo</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>${mavengem.wagon.version}</version>
+      </extension>
+      <extension>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-extension</artifactId>
+        <version>${jruby.plugins.version}</version>
+      </extension>
+    </extensions>
+    <plugins>
+      <plugin>
+        <configuration>
+          <gemspec>bouncy-castle-java.gemspec</gemspec>
+        </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
+      </plugin>
+    </plugins>
+    <directory>${basedir}/pkg</directory>
+  </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemspec_with_prereleased_dependency/pom.xml
+++ b/spec/gemspec_with_prereleased_dependency/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.1</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,11 +23,11 @@
   </properties>
   <dependencies>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>minitest</artifactId>
       <version>[4.4.alhpa-SNAPSHOT,4.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>
@@ -48,16 +36,21 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
     <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
       <id>rubygems-prereleases</id>
       <url>http://rubygems-proxy.torquebox.org/prereleases</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.1</version>
   <build>
     <extensions>
       <extension>
@@ -71,16 +64,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemspec_with_prereleased_dependency_and_no_repo/pom.xml
+++ b/spec/gemspec_with_prereleased_dependency_and_no_repo/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.1</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,25 +23,30 @@
   </properties>
   <dependencies>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>minitest</artifactId>
       <version>[4.4.alhpa-SNAPSHOT,4.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>
     <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
       <id>rubygems-prereleases</id>
       <url>http://rubygems-proxy.torquebox.org/prereleases</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.1</version>
   <build>
     <extensions>
       <extension>
@@ -67,16 +60,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemspec_with_source/pom.xml
+++ b/spec/gemspec_with_source/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0149</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -51,6 +39,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0149</version>
   <build>
     <extensions>
       <extension>
@@ -64,27 +57,24 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
         <executions>
           <execution>
-            <phase>prepare-package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
+            <phase>prepare-package</phase>
           </execution>
         </executions>
         <configuration>
           <outputDirectory>mylib</outputDirectory>
           <finalName>bouncy-castle-java</finalName>
         </configuration>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>2.4</version>
         <configuration>
           <filesets>
             <fileset>
@@ -96,15 +86,25 @@
             </fileset>
           </filesets>
         </configuration>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemspec_with_source_and_custom_jarname/pom.xml
+++ b/spec/gemspec_with_source_and_custom_jarname/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,17 +23,17 @@
   </properties>
   <dependencies>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>thor</artifactId>
       <version>[0.14.6,2.0)</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>rake</artifactId>
       <version>[10.0,10.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>
@@ -54,6 +42,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0</version>
   <build>
     <extensions>
       <extension>
@@ -67,27 +60,24 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
         <executions>
           <execution>
-            <phase>prepare-package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
+            <phase>prepare-package</phase>
           </execution>
         </executions>
         <configuration>
           <outputDirectory>mylib</outputDirectory>
           <finalName>green</finalName>
         </configuration>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>2.4</version>
         <configuration>
           <filesets>
             <fileset>
@@ -99,15 +89,25 @@
             </fileset>
           </filesets>
         </configuration>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/gemspec_with_source_and_no_jar/pom.xml
+++ b/spec/gemspec_with_source_and_no_jar/pom.xml
@@ -10,24 +10,12 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>bouncy-castle-java</artifactId>
-  <version>1.5.0</version>
-  <packaging>gem</packaging>
-  <name>Gem redistribution of Bouncy Castle jars</name>
-  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
   <developers>
     <developer>
       <name>Hiroshi Nakamura</name>
       <email>nahi@ruby-lang.org</email>
     </developer>
   </developers>
-  <scm>
-    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
-    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <jruby.plugins.version>2.0.1</jruby.plugins.version>
@@ -35,17 +23,17 @@
   </properties>
   <dependencies>
     <dependency>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>thor</artifactId>
       <version>[0.14.6,2.0)</version>
-      <type>gem</type>
     </dependency>
     <dependency>
+      <scope>test</scope>
+      <type>gem</type>
       <groupId>rubygems</groupId>
       <artifactId>rake</artifactId>
       <version>[10.0,10.99999]</version>
-      <type>gem</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>
@@ -54,6 +42,11 @@
       <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Gem redistribution of Bouncy Castle jars</name>
+  <groupId>rubygems</groupId>
+  <artifactId>bouncy-castle-java</artifactId>
+  <version>1.5.0</version>
   <build>
     <extensions>
       <extension>
@@ -67,16 +60,23 @@
         <version>${jruby.plugins.version}</version>
       </extension>
     </extensions>
-    <directory>${basedir}/pkg</directory>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>${jruby.plugins.version}</version>
         <configuration>
           <gemspec>bouncy-castle-java.gemspec</gemspec>
         </configuration>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
       </plugin>
     </plugins>
+    <directory>${basedir}/pkg</directory>
   </build>
+  <description>Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html</description>
+  <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  <scm>
+    <connection>https://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java.git</connection>
+    <url>http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/</url>
+  </scm>
+  <packaging>gem</packaging>
 </project>

--- a/spec/jarfile_spec.rb
+++ b/spec/jarfile_spec.rb
@@ -38,7 +38,7 @@ describe Maven::Tools::Jarfile do
 
   it 'generates lockfile' do
     subject.generate_lockfile(%w( a b c d e f ruby.bundler:bla))
-    File.read(jfile_lock).must_equal <<-EOF
+    _(File.read(jfile_lock)).must_equal <<-EOF
 a
 b
 c
@@ -55,10 +55,10 @@ a:b:pom:3
 a:c:jar:1
 EOF
     end
-    subject.locked.must_equal ["a:b:pom:3", "a:c:jar:1"]
-    subject.locked?("a:b:pom:321").must_equal true
-    subject.locked?("a:b:jar:321").must_equal true
-    subject.locked?("a:d:jar:432").must_equal false
+    _(subject.locked).must_equal ["a:b:pom:3", "a:c:jar:1"]
+    _(subject.locked?("a:b:pom:321")).must_equal true
+    _(subject.locked?("a:b:jar:321")).must_equal true
+    _(subject.locked?("a:d:jar:432")).must_equal false
   end
 
   it 'populate repositories' do
@@ -70,11 +70,11 @@ source "http://example.org/repo/3"
 EOF
     end
     subject.populate_unlocked container
-    container.repositories.size.must_equal 3
-    container.artifacts.size.must_equal 0
-    container.repositories[0].must_equal "first"
-    container.repositories[1].must_equal "second"
-    container.repositories[2].must_equal "http://example.org/repo/3"
+    _(container.repositories.size).must_equal 3
+    _(container.artifacts.size).must_equal 0
+    _(container.repositories[0]).must_equal "first"
+    _(container.repositories[1]).must_equal "second"
+    _(container.repositories[2]).must_equal "http://example.org/repo/3"
   end
 
   it 'populate artifacts without locked' do
@@ -85,10 +85,10 @@ pom 'x:y', '987'
 EOF
     end
     subject.populate_unlocked container
-    container.repositories.size.must_equal 0
-    container.artifacts.size.must_equal 2
-    container.artifacts[0].to_s.must_equal "a:b:jar:123"
-    container.artifacts[1].to_s.must_equal "x:y:pom:987"
+    _(container.repositories.size).must_equal 0
+    _(container.artifacts.size).must_equal 2
+    _(container.artifacts[0].to_s).must_equal "a:b:jar:123"
+    _(container.artifacts[1].to_s).must_equal "x:y:pom:987"
   end
 
   it 'populate artifacts with locked' do
@@ -105,9 +105,9 @@ EOF
     end
     
     subject.populate_unlocked container
-    container.repositories.size.must_equal 0
-    container.artifacts.size.must_equal 1
-    container.artifacts[0].to_s.must_equal "x:y:pom:987"
+    _(container.repositories.size).must_equal 0
+    _(container.artifacts.size).must_equal 1
+    _(container.artifacts[0].to_s).must_equal "x:y:pom:987"
   end
 
   it 'populate locked artifacts' do
@@ -118,8 +118,8 @@ EOF
     end
     
     subject.populate_locked container
-    container.repositories.size.must_equal 0
-    container.artifacts.size.must_equal 1
-    container.artifacts[0].to_s.must_equal "a:b:jar:432"
+    _(container.repositories.size).must_equal 0
+    _(container.artifacts.size).must_equal 1
+    _(container.artifacts[0].to_s).must_equal "a:b:jar:432"
   end
 end

--- a/spec/mavenfile_jrubyJar/pom.xml
+++ b/spec/mavenfile_jrubyJar/pom.xml
@@ -10,15 +10,15 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <properties>
+    <jruby9.plugins.version>0.3.0</jruby9.plugins.version>
+  </properties>
   <modelVersion>4.0.0</modelVersion>
+  <name>mavenfile_jrubyJar</name>
   <groupId>no_group_id_given</groupId>
   <artifactId>mavenfile_jrubyJar</artifactId>
   <version>0.0.0</version>
   <packaging>jrubyJar</packaging>
-  <name>mavenfile_jrubyJar</name>
-  <properties>
-    <jruby9.plugins.version>0.3.0</jruby9.plugins.version>
-  </properties>
   <build>
     <extensions>
       <extension>
@@ -29,10 +29,10 @@
     </extensions>
     <resources>
       <resource>
-        <directory>${basedir}</directory>
         <includes>
           <include>something</include>
         </includes>
+        <directory>${basedir}</directory>
       </resource>
     </resources>
     <directory>${basedir}/pkg</directory>

--- a/spec/mavenfile_jrubyWar/pom.xml
+++ b/spec/mavenfile_jrubyWar/pom.xml
@@ -10,15 +10,15 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <properties>
+    <jruby9.plugins.version>0.3.0</jruby9.plugins.version>
+  </properties>
   <modelVersion>4.0.0</modelVersion>
+  <name>mavenfile_jrubyWar</name>
   <groupId>no_group_id_given</groupId>
   <artifactId>mavenfile_jrubyWar</artifactId>
   <version>0.0.0</version>
   <packaging>jrubyWar</packaging>
-  <name>mavenfile_jrubyWar</name>
-  <properties>
-    <jruby9.plugins.version>0.3.0</jruby9.plugins.version>
-  </properties>
   <build>
     <extensions>
       <extension>
@@ -29,10 +29,10 @@
     </extensions>
     <resources>
       <resource>
-        <directory>${basedir}</directory>
         <includes>
           <include>something</include>
         </includes>
+        <directory>${basedir}</directory>
       </resource>
     </resources>
     <directory>${basedir}/pkg</directory>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -98,6 +98,10 @@
   </dependencies>
   <repositories>
     <repository>
+      <id>first</id>
+      <url>http://repo.example.com</url>
+      <name>First</name>
+      <layout>legacy</layout>
       <releases>
         <enabled>true</enabled>
         <updatePolicy>daily</updatePolicy>
@@ -108,28 +112,65 @@
         <updatePolicy>never</updatePolicy>
         <checksumPolicy>none</checksumPolicy>
       </snapshots>
-      <id>first</id>
-      <name>First</name>
-      <url>http://repo.example.com</url>
-      <layout>legacy</layout>
     </repository>
     <repository>
-      <releases>
-        <enabled>false</enabled>
-        <updatePolicy>daily</updatePolicy>
-        <checksumPolicy>strict</checksumPolicy>
-      </releases>
       <snapshots>
         <enabled>true</enabled>
         <updatePolicy>never</updatePolicy>
         <checksumPolicy>none</checksumPolicy>
       </snapshots>
+      <releases>
+        <enabled>false</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>strict</checksumPolicy>
+      </releases>
       <id>snapshots</id>
-      <name>First Snapshots</name>
       <url>http://snaphots.example.com</url>
+      <name>First Snapshots</name>
       <layout>legacy</layout>
     </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>first</id>
+      <url>http://pluginrepo.example.com</url>
+      <name>First</name>
+      <layout>legacy</layout>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>strict</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>none</checksumPolicy>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+  <profiles>
+    <profile>
+      <id>one</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <jdk>1.7</jdk>
+        <os>
+          <family>nix</family>
+          <version>2.7</version>
+          <arch>x86_64</arch>
+          <name>linux</name>
+        </os>
+        <file>
+          <missing>required_file</missing>
+          <exists>optional</exists>
+        </file>
+        <property>
+          <name>test</name>
+          <value>extended</value>
+        </property>
+      </activation>
+    </profile>
+  </profiles>
   <modelVersion>1.0.1</modelVersion>
   <name>my name</name>
   <artifactId>project</artifactId>
@@ -187,8 +228,8 @@
     <downloadUrl>http://dev.example.com/downloads</downloadUrl>
     <repository>
       <id>first</id>
-      <name>First</name>
       <url>http://repo.example.com</url>
+      <name>First</name>
       <layout>legacy</layout>
       <releases>
         <enabled>true</enabled>
@@ -203,8 +244,8 @@
     </repository>
     <snapshotRepository>
       <id>snapshots</id>
-      <name>First Snapshots</name>
       <url>http://snaphots.example.com</url>
+      <name>First Snapshots</name>
       <layout>legacy</layout>
       <releases>
         <enabled>false</enabled>
@@ -232,12 +273,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.example</groupId>
-        <artifactId>tools</artifactId>
-        <version>1.2.3</version>
-        <classifier>super</classifier>
-        <scope>provided</scope>
-        <systemPath>/home/development/tools.jar</systemPath>
         <exclusions>
           <exclusion>
             <groupId>org.example</groupId>
@@ -248,52 +283,16 @@
             <artifactId>something</artifactId>
           </exclusion>
         </exclusions>
+        <groupId>com.example</groupId>
+        <artifactId>tools</artifactId>
+        <version>1.2.3</version>
+        <classifier>super</classifier>
+        <scope>provided</scope>
+        <systemPath>/home/development/tools.jar</systemPath>
         <optional>true</optional>
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>daily</updatePolicy>
-        <checksumPolicy>strict</checksumPolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
-        <checksumPolicy>none</checksumPolicy>
-      </snapshots>
-      <id>first</id>
-      <name>First</name>
-      <url>http://pluginrepo.example.com</url>
-      <layout>legacy</layout>
-    </pluginRepository>
-  </pluginRepositories>
-  <profiles>
-    <profile>
-      <id>one</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-        <jdk>1.7</jdk>
-        <os>
-          <name>linux</name>
-          <family>nix</family>
-          <arch>x86_64</arch>
-          <version>2.7</version>
-        </os>
-        <property>
-          <name>test</name>
-          <value>extended</value>
-        </property>
-        <file>
-          <missing>required_file</missing>
-          <exists>optional</exists>
-        </file>
-      </activation>
-    </profile>
-  </profiles>
   <build>
     <extensions>
       <extension>
@@ -304,28 +303,28 @@
     </extensions>
     <resources>
       <resource>
-        <targetPath>target</targetPath>
-        <filtering>true</filtering>
-        <directory>resources</directory>
         <includes>
           <include>**/*</include>
         </includes>
         <excludes>
           <exclude>*~</exclude>
         </excludes>
+        <targetPath>target</targetPath>
+        <filtering>true</filtering>
+        <directory>resources</directory>
       </resource>
     </resources>
     <testResources>
       <testResource>
-        <targetPath>target/test</targetPath>
-        <filtering>false</filtering>
-        <directory>testresources</directory>
         <includes>
           <include>**/*</include>
         </includes>
         <excludes>
           <exclude>*~</exclude>
         </excludes>
+        <targetPath>target/test</targetPath>
+        <filtering>false</filtering>
+        <directory>testresources</directory>
       </testResource>
     </testResources>
     <plugins>
@@ -373,8 +372,8 @@
                 </chmod>
               </tasks>
             </configuration>
-            <phase>package</phase>
             <id>copy</id>
+            <phase>package</phase>
           </execution>
         </executions>
         <dependencies>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -90,10 +90,10 @@
       <artifactId>tools</artifactId>
       <version>2.3</version>
       <type>war</type>
-      <classifier>super</classifier>
-      <scope>provided</scope>
       <systemPath>/home/development/wartools.jar</systemPath>
+      <classifier>super</classifier>
       <optional>false</optional>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <repositories>
@@ -286,10 +286,10 @@
         <groupId>com.example</groupId>
         <artifactId>tools</artifactId>
         <version>1.2.3</version>
-        <classifier>super</classifier>
-        <scope>provided</scope>
         <systemPath>/home/development/tools.jar</systemPath>
+        <classifier>super</classifier>
         <optional>true</optional>
+        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -10,23 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>1.0.1</modelVersion>
-  <parent>
-    <groupId>example</groupId>
-    <artifactId>parent</artifactId>
-    <version>1.1</version>
-    <relativePath>../pom.xml</relativePath>
-  </parent>
-  <artifactId>project</artifactId>
-  <packaging>jar</packaging>
-  <name>my name</name>
-  <url>example.com</url>
-  <description>some description</description>
-  <inceptionYear>2020</inceptionYear>
-  <organization>
-    <name>ngo</name>
-    <url>ngo.org</url>
-  </organization>
   <licenses>
     <license>
       <name>AGPL</name>
@@ -37,174 +20,62 @@
   </licenses>
   <developers>
     <developer>
+      <roles>
+        <role>developer</role>
+        <role>architect</role>
+      </roles>
+      <properties>
+        <gender>male</gender>
+      </properties>
       <id>1</id>
       <name>first</name>
       <url>example.com/first</url>
       <email>first@example.com</email>
       <organization>orga</organization>
       <organizationUrl>example.org</organizationUrl>
-      <roles>
-        <role>developer</role>
-        <role>architect</role>
-      </roles>
       <timezone>IST</timezone>
-      <properties>
-        <gender>male</gender>
-      </properties>
     </developer>
   </developers>
   <contributors>
     <contributor>
+      <roles>
+        <role>developer</role>
+        <role>architect</role>
+      </roles>
+      <properties>
+        <gender>male</gender>
+      </properties>
       <name>first</name>
       <url>example.com/first</url>
       <email>first@example.com</email>
       <organization>orga</organization>
       <organizationUrl>example.org</organizationUrl>
-      <roles>
-        <role>developer</role>
-        <role>architect</role>
-      </roles>
       <timezone>IST</timezone>
-      <properties>
-        <gender>male</gender>
-      </properties>
     </contributor>
   </contributors>
   <mailingLists>
     <mailingList>
+      <otherArchives>
+        <otherArchive>example.com/archive1</otherArchive>
+        <otherArchive>example.com/archive2</otherArchive>
+      </otherArchives>
       <name>development</name>
       <subscribe>subcribe@example.com</subscribe>
       <unsubscribe>unsubcribe@example.com</unsubscribe>
       <post>post@example.com</post>
       <archive>example.com/archive</archive>
-      <otherArchives>
-        <otherArchive>example.com/archive1</otherArchive>
-        <otherArchive>example.com/archive2</otherArchive>
-      </otherArchives>
     </mailingList>
   </mailingLists>
-  <prerequisites>
-    <maven>3.0.5</maven>
-  </prerequisites>
   <modules>
     <module>part1</module>
     <module>part2</module>
   </modules>
-  <scm>
-    <connection>scm:git:git://github.com/torquebox/maven-tools.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/torquebox/maven-tools.git</developerConnection>
-    <tag>first</tag>
-    <url>http://github.com/torquebox/maven-tools</url>
-  </scm>
-  <issueManagement>
-    <system>jira</system>
-    <url>https://issues.sonatype.org/</url>
-  </issueManagement>
-  <ciManagement>
-    <system>travis</system>
-    <url>travis-ci.org/jruby/jruby</url>
-    <notifiers>
-      <notifier>
-        <type>email</type>
-        <address>mail2@example.com</address>
-      </notifier>
-      <notifier>
-        <type>email</type>
-        <sendOnError>true</sendOnError>
-        <sendOnFailure>false</sendOnFailure>
-        <sendOnSuccess>true</sendOnSuccess>
-        <sendOnWarning>false</sendOnWarning>
-        <address>mail@example.com</address>
-        <configuration>
-          <key1>value1</key1>
-          <key2>value2</key2>
-        </configuration>
-      </notifier>
-    </notifiers>
-  </ciManagement>
-  <distributionManagement>
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>daily</updatePolicy>
-        <checksumPolicy>strict</checksumPolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
-        <checksumPolicy>none</checksumPolicy>
-      </snapshots>
-      <id>first</id>
-      <name>First</name>
-      <url>http://repo.example.com</url>
-      <layout>legacy</layout>
-    </repository>
-    <snapshotRepository>
-      <releases>
-        <enabled>false</enabled>
-        <updatePolicy>daily</updatePolicy>
-        <checksumPolicy>strict</checksumPolicy>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-        <checksumPolicy>none</checksumPolicy>
-      </snapshots>
-      <id>snapshots</id>
-      <name>First Snapshots</name>
-      <url>http://snaphots.example.com</url>
-      <layout>legacy</layout>
-    </snapshotRepository>
-    <site>
-      <id>first</id>
-      <name>dev site</name>
-      <url>http://dev.example.com</url>
-    </site>
-    <downloadUrl>http://dev.example.com/downloads</downloadUrl>
-    <status>active</status>
-    <relocation>
-      <groupId>org.group</groupId>
-      <artifactId>artifact</artifactId>
-      <version>1.2.3</version>
-      <message>follow the maven convention</message>
-    </relocation>
-  </distributionManagement>
   <properties>
     <key1>value1</key1>
     <key2>value2</key2>
   </properties>
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.example</groupId>
-        <artifactId>tools</artifactId>
-        <version>1.2.3</version>
-        <classifier>super</classifier>
-        <scope>provided</scope>
-        <systemPath>/home/development/tools.jar</systemPath>
-        <exclusions>
-          <exclusion>
-            <groupId>org.example</groupId>
-            <artifactId>some</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.example</groupId>
-            <artifactId>something</artifactId>
-          </exclusion>
-        </exclusions>
-        <optional>true</optional>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>com.example</groupId>
-      <artifactId>tools</artifactId>
-      <version>2.3</version>
-      <type>war</type>
-      <classifier>super</classifier>
-      <scope>provided</scope>
-      <systemPath>/home/development/wartools.jar</systemPath>
       <exclusions>
         <exclusion>
           <groupId>org.example</groupId>
@@ -215,6 +86,13 @@
           <artifactId>something</artifactId>
         </exclusion>
       </exclusions>
+      <groupId>com.example</groupId>
+      <artifactId>tools</artifactId>
+      <version>2.3</version>
+      <type>war</type>
+      <classifier>super</classifier>
+      <scope>provided</scope>
+      <systemPath>/home/development/wartools.jar</systemPath>
       <optional>false</optional>
     </dependency>
   </dependencies>
@@ -252,6 +130,129 @@
       <layout>legacy</layout>
     </repository>
   </repositories>
+  <modelVersion>1.0.1</modelVersion>
+  <name>my name</name>
+  <artifactId>project</artifactId>
+  <url>example.com</url>
+  <parent>
+    <groupId>example</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.1</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <packaging>jar</packaging>
+  <description>some description</description>
+  <inceptionYear>2020</inceptionYear>
+  <organization>
+    <name>ngo</name>
+    <url>ngo.org</url>
+  </organization>
+  <prerequisites>
+    <maven>3.0.5</maven>
+  </prerequisites>
+  <scm>
+    <connection>scm:git:git://github.com/torquebox/maven-tools.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/torquebox/maven-tools.git</developerConnection>
+    <url>http://github.com/torquebox/maven-tools</url>
+    <tag>first</tag>
+  </scm>
+  <issueManagement>
+    <url>https://issues.sonatype.org/</url>
+    <system>jira</system>
+  </issueManagement>
+  <ciManagement>
+    <notifiers>
+      <notifier>
+        <type>email</type>
+        <address>mail2@example.com</address>
+      </notifier>
+      <notifier>
+        <configuration>
+          <key1>value1</key1>
+          <key2>value2</key2>
+        </configuration>
+        <type>email</type>
+        <address>mail@example.com</address>
+        <sendOnError>true</sendOnError>
+        <sendOnFailure>false</sendOnFailure>
+        <sendOnSuccess>true</sendOnSuccess>
+        <sendOnWarning>false</sendOnWarning>
+      </notifier>
+    </notifiers>
+    <url>travis-ci.org/jruby/jruby</url>
+    <system>travis</system>
+  </ciManagement>
+  <distributionManagement>
+    <status>active</status>
+    <downloadUrl>http://dev.example.com/downloads</downloadUrl>
+    <repository>
+      <id>first</id>
+      <name>First</name>
+      <url>http://repo.example.com</url>
+      <layout>legacy</layout>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>strict</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>none</checksumPolicy>
+      </snapshots>
+    </repository>
+    <snapshotRepository>
+      <id>snapshots</id>
+      <name>First Snapshots</name>
+      <url>http://snaphots.example.com</url>
+      <layout>legacy</layout>
+      <releases>
+        <enabled>false</enabled>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>strict</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>none</checksumPolicy>
+      </snapshots>
+    </snapshotRepository>
+    <site>
+      <id>first</id>
+      <url>http://dev.example.com</url>
+      <name>dev site</name>
+    </site>
+    <relocation>
+      <groupId>org.group</groupId>
+      <artifactId>artifact</artifactId>
+      <version>1.2.3</version>
+      <message>follow the maven convention</message>
+    </relocation>
+  </distributionManagement>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.example</groupId>
+        <artifactId>tools</artifactId>
+        <version>1.2.3</version>
+        <classifier>super</classifier>
+        <scope>provided</scope>
+        <systemPath>/home/development/tools.jar</systemPath>
+        <exclusions>
+          <exclusion>
+            <groupId>org.example</groupId>
+            <artifactId>some</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.example</groupId>
+            <artifactId>something</artifactId>
+          </exclusion>
+        </exclusions>
+        <optional>true</optional>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <pluginRepositories>
     <pluginRepository>
       <releases>
@@ -270,12 +271,30 @@
       <layout>legacy</layout>
     </pluginRepository>
   </pluginRepositories>
+  <profiles>
+    <profile>
+      <id>one</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <jdk>1.7</jdk>
+        <os>
+          <name>linux</name>
+          <family>nix</family>
+          <arch>x86_64</arch>
+          <version>2.7</version>
+        </os>
+        <property>
+          <name>test</name>
+          <value>extended</value>
+        </property>
+        <file>
+          <missing>required_file</missing>
+          <exists>optional</exists>
+        </file>
+      </activation>
+    </profile>
+  </profiles>
   <build>
-    <sourceDirectory>src</sourceDirectory>
-    <scriptSourceDirectory>script</scriptSourceDirectory>
-    <testSourceDirectory>test</testSourceDirectory>
-    <outputDirectory>pkg</outputDirectory>
-    <testOutputDirectory>pkg/test</testOutputDirectory>
     <extensions>
       <extension>
         <groupId>org.group</groupId>
@@ -283,7 +302,6 @@
         <version>1.2</version>
       </extension>
     </extensions>
-    <defaultGoal>deploy</defaultGoal>
     <resources>
       <resource>
         <targetPath>target</targetPath>
@@ -310,14 +328,100 @@
         </excludes>
       </testResource>
     </testResources>
+    <plugins>
+      <plugin>
+        <configuration>
+          <finalName>testing</finalName>
+        </configuration>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>1.0</version>
+        <inherited>false</inherited>
+        <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <dependencies>
+          <dependency>
+            <groupId>rubygems</groupId>
+            <artifactId>bundler</artifactId>
+            <version>1.7.13</version>
+            <type>gem</type>
+          </dependency>
+        </dependencies>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <extensions>false</extensions>
+      </plugin>
+      <plugin>
+        <executions>
+          <execution>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks>
+                <exec
+                  executable="/bin/sh"
+                  osfamily="unix">
+                  <arg
+                    line="-c 'cp &quot;${jruby.basedir}/bin/jruby.bash&quot; &quot;${jruby.basedir}/bin/jruby&quot;'">
+                  </arg>
+                </exec>
+                <chmod
+                  file="${jruby.basedir}/bin/jruby"
+                  perm="755">
+                </chmod>
+              </tasks>
+            </configuration>
+            <phase>package</phase>
+            <id>copy</id>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.super.duper</groupId>
+            <artifactId>executor</artifactId>
+            <version>1.0.0</version>
+          </dependency>
+        </dependencies>
+        <artifactId>maven-antrun-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <executions>
+          <execution>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <arguments>
+                <argument>-Djruby.bytecode.version=${base.java.version}</argument>
+                <argument>-classpath</argument>
+                <classpath/>
+                <argument>org.jruby.anno.InvokerGenerator</argument>
+                <argument>${anno.sources}/annotated_classes.txt</argument>
+                <argument>${project.build.outputDirectory}</argument>
+              </arguments>
+              <executable>java</executable>
+              <classpathScope>compile</classpathScope>
+            </configuration>
+            <id>invoker-generator</id>
+          </execution>
+        </executions>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+    <defaultGoal>deploy</defaultGoal>
     <directory>target</directory>
     <finalName>myproject</finalName>
+    <sourceDirectory>src</sourceDirectory>
+    <scriptSourceDirectory>script</scriptSourceDirectory>
+    <testSourceDirectory>test</testSourceDirectory>
+    <outputDirectory>pkg</outputDirectory>
+    <testOutputDirectory>pkg/test</testOutputDirectory>
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>de.saumya.mojo</groupId>
-          <artifactId>gem-maven-plugin</artifactId>
-          <version>2.0.1</version>
           <configuration>
             <scope>compile</scope>
             <gems>
@@ -325,11 +429,11 @@
               <jdbc-mysql>5.1.30</jdbc-mysql>
             </gems>
           </configuration>
+          <groupId>de.saumya.mojo</groupId>
+          <artifactId>gem-maven-plugin</artifactId>
+          <version>2.0.1</version>
         </plugin>
         <plugin>
-          <groupId>org.mortbay.jetty</groupId>
-          <artifactId>jetty-maven-plugin</artifactId>
-          <version>8.1</version>
           <configuration>
             <path>/</path>
             <connectors>
@@ -349,114 +453,11 @@
               <port>${run.port}</port>
             </httpConnector>
           </configuration>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jetty-maven-plugin</artifactId>
+          <version>8.1</version>
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>1.0</version>
-        <extensions>true</extensions>
-        <inherited>false</inherited>
-        <configuration>
-          <finalName>testing</finalName>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-maven-plugin</artifactId>
-        <version>1.0.0</version>
-        <extensions>false</extensions>
-        <dependencies>
-          <dependency>
-            <groupId>rubygems</groupId>
-            <artifactId>bundler</artifactId>
-            <version>1.7.13</version>
-            <type>gem</type>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy</id>
-            <phase>package</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <tasks>
-                <exec
-                  executable="/bin/sh"
-                  osfamily="unix">
-                  <arg
-                    line="-c 'cp &quot;${jruby.basedir}/bin/jruby.bash&quot; &quot;${jruby.basedir}/bin/jruby&quot;'">
-                  </arg>
-                </exec>
-                <chmod
-                  file="${jruby.basedir}/bin/jruby"
-                  perm="755">
-                </chmod>
-              </tasks>
-            </configuration>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>org.super.duper</groupId>
-            <artifactId>executor</artifactId>
-            <version>1.0.0</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>invoker-generator</id>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <arguments>
-                <argument>-Djruby.bytecode.version=${base.java.version}</argument>
-                <argument>-classpath</argument>
-                <classpath/>
-                <argument>org.jruby.anno.InvokerGenerator</argument>
-                <argument>${anno.sources}/annotated_classes.txt</argument>
-                <argument>${project.build.outputDirectory}</argument>
-              </arguments>
-              <executable>java</executable>
-              <classpathScope>compile</classpathScope>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>one</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-        <jdk>1.7</jdk>
-        <os>
-          <name>linux</name>
-          <family>nix</family>
-          <arch>x86_64</arch>
-          <version>2.7</version>
-        </os>
-        <property>
-          <name>test</name>
-          <value>extended</value>
-        </property>
-        <file>
-          <missing>required_file</missing>
-          <exists>optional</exists>
-        </file>
-      </activation>
-    </profile>
-  </profiles>
 </project>

--- a/spec/pom_from_jarfile/pom.xml
+++ b/spec/pom_from_jarfile/pom.xml
@@ -10,11 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>pom_from_jarfile</artifactId>
-  <version>0.0.0</version>
-  <name>example from jarfile</name>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -25,8 +20,13 @@
       <groupId>ruby.maven-tools.jar</groupId>
       <artifactId>myfirst</artifactId>
       <version>0</version>
-      <scope>system</scope>
       <systemPath>${basedir}/myfirst.jar</systemPath>
+      <scope>system</scope>
     </dependency>
   </dependencies>
+  <modelVersion>4.0.0</modelVersion>
+  <name>example from jarfile</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>pom_from_jarfile</artifactId>
+  <version>0.0.0</version>
 </project>

--- a/spec/pom_from_jarfile_and_empty_lock/pom.xml
+++ b/spec/pom_from_jarfile_and_empty_lock/pom.xml
@@ -10,11 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>pom_from_jarfile_and_empty_lock</artifactId>
-  <version>0.0.0</version>
-  <name>example from jarfile</name>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -27,4 +22,9 @@
       <version>[1.6.4,1.6.99999]</version>
     </dependency>
   </dependencies>
+  <modelVersion>4.0.0</modelVersion>
+  <name>example from jarfile</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>pom_from_jarfile_and_empty_lock</artifactId>
+  <version>0.0.0</version>
 </project>

--- a/spec/pom_from_jarfile_and_lock/pom.xml
+++ b/spec/pom_from_jarfile_and_lock/pom.xml
@@ -10,11 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>pom_from_jarfile_and_lock</artifactId>
-  <version>0.0.0</version>
-  <name>example from jarfile</name>
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -34,4 +29,9 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <modelVersion>4.0.0</modelVersion>
+  <name>example from jarfile</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>pom_from_jarfile_and_lock</artifactId>
+  <version>0.0.0</version>
 </project>

--- a/spec/pom_from_jarfile_and_lock/pom2.xml
+++ b/spec/pom_from_jarfile_and_lock/pom2.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>pom_from_jarfile</artifactId>
-  <version>0.0.0</version>
-  <name>example from jarfile</name>
   <properties>
     <tesla.dump.pom>pom2.xml</tesla.dump.pom>
   </properties>
@@ -31,11 +26,16 @@
       <version>1.49</version>
     </dependency>
     <dependency>
+      <scope>provided</scope>
+      <type>pom</type>
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
       <version>1.7.13</version>
-      <type>pom</type>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
+  <modelVersion>4.0.0</modelVersion>
+  <name>example from jarfile</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>pom_from_jarfile</artifactId>
+  <version>0.0.0</version>
 </project>

--- a/spec/pom_from_jarfile_and_skip_lock/pom.xml
+++ b/spec/pom_from_jarfile_and_skip_lock/pom.xml
@@ -10,11 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>pom_from_jarfile_and_skip_lock</artifactId>
-  <version>0.0.0</version>
-  <name>example from jarfile</name>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -28,4 +23,9 @@
       <version>[1.6.4,1.6.99999]</version>
     </dependency>
   </dependencies>
+  <modelVersion>4.0.0</modelVersion>
+  <name>example from jarfile</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>pom_from_jarfile_and_skip_lock</artifactId>
+  <version>0.0.0</version>
 </project>

--- a/spec/pom_from_jarfile_help_only/pom.xml
+++ b/spec/pom_from_jarfile_help_only/pom.xml
@@ -10,15 +10,8 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>pom_from_jarfile_help_only</artifactId>
-  <version>0.0.0</version>
-  <name>example from jarfile</name>
   <dependencies>
     <dependency>
-      <groupId>asd</groupId>
-      <artifactId>asd</artifactId>
       <exclusions>
         <exclusion>
           <groupId>asd</groupId>
@@ -27,11 +20,18 @@
         <exclusion>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
       <groupId>asd</groupId>
       <artifactId>asd</artifactId>
+    </dependency>
+    <dependency>
       <type>pom</type>
+      <groupId>asd</groupId>
+      <artifactId>asd</artifactId>
     </dependency>
   </dependencies>
+  <modelVersion>4.0.0</modelVersion>
+  <name>example from jarfile</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>pom_from_jarfile_help_only</artifactId>
+  <version>0.0.0</version>
 </project>

--- a/spec/pom_from_jarfile_with_exclusions/pom.xml
+++ b/spec/pom_from_jarfile_with_exclusions/pom.xml
@@ -9,18 +9,8 @@
 
 -->
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>pom_from_jarfile_with_exclusions</artifactId>
-  <version>0.0.0</version>
-  <name>example from jarfile</name>
   <dependencies>
     <dependency>
-      <groupId>asd</groupId>
-      <artifactId>asd</artifactId>
-      <version>123</version>
-      <classifier>source</classifier>
-      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>group</groupId>
@@ -35,8 +25,8 @@
           <artifactId>a3</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>group</groupId>
           <artifactId>a4</artifactId>
+          <groupId>group</groupId>
         </exclusion>
         <exclusion>
           <groupId>group</groupId>
@@ -51,12 +41,13 @@
           <artifactId>a7</artifactId>
         </exclusion>
       </exclusions>
+      <scope>test</scope>
+      <classifier>source</classifier>
+      <groupId>asd</groupId>
+      <artifactId>asd</artifactId>
+      <version>123</version>
     </dependency>
     <dependency>
-      <groupId>dsa</groupId>
-      <artifactId>dsa</artifactId>
-      <version>12</version>
-      <classifier>provided</classifier>
       <exclusions>
         <exclusion>
           <groupId>group</groupId>
@@ -71,6 +62,15 @@
           <artifactId>b3</artifactId>
         </exclusion>
       </exclusions>
+      <groupId>dsa</groupId>
+      <artifactId>dsa</artifactId>
+      <version>12</version>
+      <classifier>provided</classifier>
     </dependency>
   </dependencies>
+  <modelVersion>4.0.0</modelVersion>
+  <name>example from jarfile</name>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>pom_from_jarfile_with_exclusions</artifactId>
+  <version>0.0.0</version>
 </project>

--- a/spec/pom_from_jarfile_with_jruby/pom.xml
+++ b/spec/pom_from_jarfile_with_jruby/pom.xml
@@ -10,8 +10,8 @@
 -->
 <project>
   <modelVersion>4.0.0</modelVersion>
+  <name>example from jarfile</name>
   <groupId>no_group_id_given</groupId>
   <artifactId>pom_from_jarfile_with_jruby</artifactId>
   <version>0.0.0</version>
-  <name>example from jarfile</name>
 </project>

--- a/spec/pom_from_jarfile_with_repos/pom.xml
+++ b/spec/pom_from_jarfile_with_repos/pom.xml
@@ -10,10 +10,6 @@
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>no_group_id_given</groupId>
-  <artifactId>pom_from_jarfile_with_repos</artifactId>
-  <version>0.0.0</version>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -24,24 +20,28 @@
   <repositories>
     <repository>
       <id>http://1.2.3.4/artifactory/</id>
-      <name>http://1.2.3.4/artifactory/</name>
       <url>http://1.2.3.4/artifactory/</url>
+      <name>http://1.2.3.4/artifactory/</name>
     </repository>
     <repository>
       <id>takari</id>
-      <name>takari</name>
       <url>http://otto.takari.io:8081/nexus/content/groups/public</url>
+      <name>takari</name>
     </repository>
     <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
       <id>tesla</id>
-      <name>tesla</name>
       <url>http://repository.tesla.io:8081/nexus/content/groups/public</url>
+      <name>tesla</name>
     </repository>
   </repositories>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>pom_from_jarfile_with_repos</artifactId>
+  <version>0.0.0</version>
 </project>

--- a/spec/pom_spec.rb
+++ b/spec/pom_spec.rb
@@ -18,7 +18,7 @@ describe Maven::Tools::POM do
         pom_xml.gsub!( /tesla-polyglot/, 'polyglot' )
         pom_xml.gsub!( /${tesla.version}/, Maven::Tools::VERSIONS[ :polyglot_version ] )
 
-        pom.to_s.must_equal pom_xml
+        _(pom.to_s).must_equal pom_xml
       end
     end
   end

--- a/spec/pom_with_execute/pom.xml
+++ b/spec/pom_with_execute/pom.xml
@@ -11,29 +11,24 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
+  <name>example with execute</name>
   <groupId>no_group_id_given</groupId>
   <artifactId>pom_with_execute</artifactId>
   <version>0.0.0</version>
-  <name>example with execute</name>
   <build>
     <plugins>
       <plugin>
-        <groupId>io.takari.polyglot</groupId>
-        <artifactId>polyglot-maven-plugin</artifactId>
-        <version>0.1.18</version>
         <executions>
           <execution>
-            <phase>validate</phase>
             <goals>
               <goal>execute</goal>
             </goals>
             <configuration>
               <nativePom>pom.rb</nativePom>
             </configuration>
+            <phase>validate</phase>
           </execution>
           <execution>
-            <id>second</id>
-            <phase>validate</phase>
             <goals>
               <goal>execute</goal>
             </goals>
@@ -41,10 +36,10 @@
               <taskId>second</taskId>
               <nativePom>pom.rb</nativePom>
             </configuration>
+            <id>second</id>
+            <phase>validate</phase>
           </execution>
           <execution>
-            <id>third</id>
-            <phase>validate</phase>
             <goals>
               <goal>execute</goal>
             </goals>
@@ -52,10 +47,10 @@
               <taskId>third</taskId>
               <nativePom>pom.rb</nativePom>
             </configuration>
+            <id>third</id>
+            <phase>validate</phase>
           </execution>
           <execution>
-            <id>forth</id>
-            <phase>validate</phase>
             <goals>
               <goal>execute</goal>
             </goals>
@@ -63,10 +58,10 @@
               <taskId>forth</taskId>
               <nativePom>pom.rb</nativePom>
             </configuration>
+            <id>forth</id>
+            <phase>validate</phase>
           </execution>
           <execution>
-            <id>fifth</id>
-            <phase>validate</phase>
             <goals>
               <goal>execute</goal>
             </goals>
@@ -74,6 +69,8 @@
               <taskId>fifth</taskId>
               <nativePom>pom.rb</nativePom>
             </configuration>
+            <id>fifth</id>
+            <phase>validate</phase>
           </execution>
         </executions>
         <dependencies>
@@ -83,6 +80,9 @@
             <version>0.1.18</version>
           </dependency>
         </dependencies>
+        <groupId>io.takari.polyglot</groupId>
+        <artifactId>polyglot-maven-plugin</artifactId>
+        <version>0.1.18</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
The model for the project was built on [virtus](https://github.com/solnic/virtus/) a gem which has been deprecated. Unfortunately Virtus depends on axiom-types which is incompatible with newer releases of Ruby - https://github.com/dkubb/axiom-types/pull/18

This migrates to the successor of virtus, [dry-types](https://github.com/dry-rb/dry-types/)


